### PR TITLE
Test/147/creating tests members services

### DIFF
--- a/new-api/package.json
+++ b/new-api/package.json
@@ -100,7 +100,8 @@
     "moduleNameMapper": {
       "@modules/(.*)": "<rootDir>/v2/modules/$1",
       "@config/(.*)": "<rootDir>/v2/config/$1",
-      "@providers/(.*)": "<rootDir>/v2/providers/$1"
+      "@providers/(.*)": "<rootDir>/v2/providers/$1",
+      "@utils/(.*)": "<rootDir>/v2/utils/$1"
     }
   }
 }

--- a/new-api/src/v2/config/upload.ts
+++ b/new-api/src/v2/config/upload.ts
@@ -1,4 +1,5 @@
 import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import { ERRORS_UNAUTHORIZED } from '@utils/Errors/Unauthorized';
 import { diskStorage, Options } from 'multer';
 import { resolve } from 'path';
 import { apiConfig } from './api';
@@ -39,7 +40,9 @@ export default {
         const member = request.user as { userId: string };
 
         if (!member) {
-          throw new UnauthorizedException(['I need to be logged in']);
+          throw new UnauthorizedException([
+            ERRORS_UNAUTHORIZED.YOU_NEED_TO_BE_LOGGED_IN,
+          ]);
         }
 
         const fileName = `${Date.now()}-${member.userId}.jpg`;

--- a/new-api/src/v2/modules/members/controllers/authMember.controller.ts
+++ b/new-api/src/v2/modules/members/controllers/authMember.controller.ts
@@ -16,6 +16,7 @@ import {
   ApiBody,
   ApiInternalServerErrorResponse,
   ApiNoContentResponse,
+  ApiNotFoundResponse,
   ApiOkResponse,
   ApiOperation,
   ApiTags,
@@ -69,6 +70,7 @@ export class ControllerAuthMember {
   @ApiOperation({ summary: "reset member's password to default" })
   @ApiInternalServerErrorResponse(Errors.InternalServer)
   @ApiUnauthorizedResponse(Errors.Unauthorized)
+  @ApiNotFoundResponse(Errors.NotFound)
   @ApiNoContentResponse({
     status: HttpStatus.NO_CONTENT,
     description: 'Updated Success',

--- a/new-api/src/v2/modules/members/controllers/authMember.controller.ts
+++ b/new-api/src/v2/modules/members/controllers/authMember.controller.ts
@@ -14,6 +14,7 @@ import {
   ApiBadRequestResponse,
   ApiBearerAuth,
   ApiBody,
+  ApiForbiddenResponse,
   ApiInternalServerErrorResponse,
   ApiNoContentResponse,
   ApiNotFoundResponse,
@@ -71,6 +72,7 @@ export class ControllerAuthMember {
   @ApiInternalServerErrorResponse(Errors.InternalServer)
   @ApiUnauthorizedResponse(Errors.Unauthorized)
   @ApiNotFoundResponse(Errors.NotFound)
+  @ApiForbiddenResponse(Errors.Forbidden)
   @ApiNoContentResponse({
     status: HttpStatus.NO_CONTENT,
     description: 'Updated Success',

--- a/new-api/src/v2/modules/members/controllers/authMember.controller.ts
+++ b/new-api/src/v2/modules/members/controllers/authMember.controller.ts
@@ -22,6 +22,7 @@ import {
   ApiOperation,
   ApiTags,
   ApiUnauthorizedResponse,
+  ApiUnprocessableEntityResponse,
 } from '@nestjs/swagger';
 import Errors from 'v2/utils/Errors';
 import { AllExceptionsFilter } from 'v2/utils/Interceptors/all-exceptions.filter';
@@ -73,6 +74,7 @@ export class ControllerAuthMember {
   @ApiUnauthorizedResponse(Errors.Unauthorized)
   @ApiNotFoundResponse(Errors.NotFound)
   @ApiForbiddenResponse(Errors.Forbidden)
+  @ApiUnprocessableEntityResponse(Errors.UnprocessableEntity)
   @ApiNoContentResponse({
     status: HttpStatus.NO_CONTENT,
     description: 'Updated Success',

--- a/new-api/src/v2/modules/members/controllers/member.controller.ts
+++ b/new-api/src/v2/modules/members/controllers/member.controller.ts
@@ -173,6 +173,9 @@ export class ControllerMember {
     type: EntityMember,
     isArray: true,
   })
+  @ApiNoContentResponse({
+    description: 'No Members Content',
+  })
   @ApiBadRequestResponse(Errors.BadRequest)
   @ApiInternalServerErrorResponse(Errors.InternalServer)
   @UsePipes(new ValidationPipe())

--- a/new-api/src/v2/modules/members/controllers/member.controller.ts
+++ b/new-api/src/v2/modules/members/controllers/member.controller.ts
@@ -73,8 +73,11 @@ export class ControllerMember {
   @ApiBearerAuth()
   @UsePipes(new ValidationPipe())
   @Post()
-  create(@Body() data: ICreateMemberBasicDataDTO) {
-    return this.serviceMember.createMember(data);
+  create(@Body() data: ICreateMemberBasicDataDTO, @Request() req: any) {
+    return this.serviceMember.createMember({
+      ...data,
+      idMemberLogged: req.user.userId,
+    });
   }
 
   @ApiOperation({ summary: 'updateInfo' })

--- a/new-api/src/v2/modules/members/controllers/member.controller.ts
+++ b/new-api/src/v2/modules/members/controllers/member.controller.ts
@@ -157,7 +157,7 @@ export class ControllerMember {
     @Param('login') login: string,
   ) {
     return this.serviceMember.updatePatentMember({
-      loggedMemberId: req.user.userId,
+      idMemberLogged: req.user.userId,
       newPatentId: body.newPatentId,
       updatedMemberLogin: login,
     });

--- a/new-api/src/v2/modules/members/dtos/ICreateMember.dto.ts
+++ b/new-api/src/v2/modules/members/dtos/ICreateMember.dto.ts
@@ -37,6 +37,12 @@ export class ICreateMemberBasicDataDTO {
     example: '2bac045b-7109-473f-af2a-32234b067694',
   })
   patentId: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @IsDefined()
+  @IsUUID()
+  idMemberLogged: string;
 }
 
 export default class ICreateMemberDTO {

--- a/new-api/src/v2/modules/members/dtos/IFindConflict.dto.ts
+++ b/new-api/src/v2/modules/members/dtos/IFindConflict.dto.ts
@@ -1,0 +1,8 @@
+export default interface IFindConflictDTO {
+  email: string;
+  login: string;
+  linkedin: string;
+  lattes: string;
+  gitHub: string;
+  quoteName: string;
+}

--- a/new-api/src/v2/modules/members/dtos/IUpdateMember.dto.ts
+++ b/new-api/src/v2/modules/members/dtos/IUpdateMember.dto.ts
@@ -143,7 +143,7 @@ export class IUpdatePatentMemberDTO {
   @IsNotEmpty()
   @IsDefined()
   @IsUUID()
-  loggedMemberId: string;
+  idMemberLogged: string;
 
   @IsString()
   @IsNotEmpty()

--- a/new-api/src/v2/modules/members/dtos/IUpdateMember.dto.ts
+++ b/new-api/src/v2/modules/members/dtos/IUpdateMember.dto.ts
@@ -106,7 +106,7 @@ export class IUpdateMemberBasicDataDTO {
   @MinLength(8)
   @ValidateIf((obj) => !!obj.newPassword)
   @IsDefined()
-  oldPassword: string;
+  oldPassword?: string;
 
   @IsString()
   @IsNotEmpty()
@@ -117,7 +117,7 @@ export class IUpdateMemberBasicDataDTO {
   })
   @ValidateIf((obj) => !!obj.oldPassword)
   @IsDefined()
-  newPassword: string;
+  newPassword?: string;
 }
 
 export class IUpdatePatentMemberRequestDTO {

--- a/new-api/src/v2/modules/members/mocks/member.mock.ts
+++ b/new-api/src/v2/modules/members/mocks/member.mock.ts
@@ -4,6 +4,10 @@ import { EntityMember } from '../typeorm/entities/member.entity';
 
 interface IGiveAMeAValidMember {
   patentName: string;
+  email?: string;
+  login?: string;
+  name?: string;
+  password?: string;
   fakeRepositoryPatent: FakeRepositoryPatent;
   fakeRepositoryMember: FakeRepositoryMember;
 }
@@ -11,6 +15,10 @@ interface IGiveAMeAValidMember {
 export default class MembersMock {
   static async giveAMeAValidMember({
     patentName,
+    email,
+    login,
+    name,
+    password,
     fakeRepositoryPatent,
     fakeRepositoryMember,
   }: IGiveAMeAValidMember): Promise<EntityMember> {
@@ -19,10 +27,10 @@ export default class MembersMock {
     });
 
     return fakeRepositoryMember.createSave({
-      email: 'user.mock@test.com',
-      login: 'user.mock',
-      name: 'User Mock',
-      password: 'fake password',
+      email: email || 'user.mock@test.com',
+      login: login || 'user.mock',
+      name: name || 'User Mock',
+      password: password || 'fake password',
       patent,
     });
   }

--- a/new-api/src/v2/modules/members/repositories/IRepositoryMember.ts
+++ b/new-api/src/v2/modules/members/repositories/IRepositoryMember.ts
@@ -1,4 +1,5 @@
 import ICreateMemberDTO from '../dtos/ICreateMember.dto';
+import IFindConflictDTO from '../dtos/IFindConflict.dto';
 import IOrderByMember from '../dtos/IOrderByMember.dto';
 import { EntityMember } from '../typeorm/entities/member.entity';
 
@@ -8,6 +9,9 @@ export default interface IRepositoryMember {
   findById(id: string): Promise<EntityMember | undefined>;
   findByEmail(email: string): Promise<EntityMember | undefined>;
   findByLogin(login: string): Promise<EntityMember | undefined>;
+  findConflict(
+    uniqueDatas: Partial<IFindConflictDTO>,
+  ): Promise<EntityMember | undefined>;
   findByLikeName(
     name: string,
     order?: IOrderByMember,

--- a/new-api/src/v2/modules/members/repositories/fakes/Member.fakeRepository.ts
+++ b/new-api/src/v2/modules/members/repositories/fakes/Member.fakeRepository.ts
@@ -1,5 +1,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
+import IFindConflictDTO from '@modules/members/dtos/IFindConflict.dto';
 import { EntityMember } from '@modules/members/typeorm/entities/member.entity';
+import { InternalServerErrorException } from '@nestjs/common';
 import ICreateMemberDTO from '../../dtos/ICreateMember.dto';
 import IOrderByMember from '../../dtos/IOrderByMember.dto';
 import IRepositoryMember from '../../repositories/IRepositoryMember';
@@ -37,6 +39,26 @@ export class FakeRepositoryMember implements IRepositoryMember {
 
   public async findByLogin(login: string): Promise<EntityMember | undefined> {
     return this.members.find((member) => member.login === login);
+  }
+
+  public async findConflict(
+    uniqueDatas: Partial<IFindConflictDTO>,
+  ): Promise<EntityMember | undefined> {
+    if (Object.keys(uniqueDatas).length === 0) {
+      throw new InternalServerErrorException([
+        'It should define  at least one attribute de uniqueDatas: email, login, linkedin, lattes, gitHub, quoteName',
+      ]);
+    }
+
+    return this.members.find(
+      (member) =>
+        (uniqueDatas.email && member.email === uniqueDatas.email) ||
+        (uniqueDatas.login && member.login === uniqueDatas.login) ||
+        (uniqueDatas.linkedin && member.linkedin === uniqueDatas.linkedin) ||
+        (uniqueDatas.lattes && member.lattes === uniqueDatas.lattes) ||
+        (uniqueDatas.gitHub && member.gitHub === uniqueDatas.gitHub) ||
+        (uniqueDatas.quoteName && member.quoteName === uniqueDatas.quoteName),
+    );
   }
 
   public async findByLikeName(

--- a/new-api/src/v2/modules/members/services/auth.service.ts
+++ b/new-api/src/v2/modules/members/services/auth.service.ts
@@ -7,6 +7,7 @@ import {
 import { JwtService } from '@nestjs/jwt';
 import { InjectRepository } from '@nestjs/typeorm';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
+import { ERRORS_UNAUTHORIZED } from '@utils/Errors/Unauthorized';
 import { IResetPasswordMemberDTO } from '../dtos/auth/IResetPasswordMember.dto';
 import { ILoginDTO } from '../dtos/ILogin.dto';
 import IPayloadTokenDTO from '../dtos/IPayloadToken.dto';
@@ -83,7 +84,7 @@ export class ServiceAuth {
       oldToken,
     );
 
-    const messagesError = ['oldToken is not valid'];
+    const messagesError = [ERRORS_UNAUTHORIZED.OLD_TOKEN_INVALID];
 
     if (!isValidToken) {
       throw new UnauthorizedException(messagesError);
@@ -114,7 +115,9 @@ export class ServiceAuth {
     const loggedMember = await this.memberRepository.findById(loggedMemberId);
 
     if (!loggedMember) {
-      throw new UnauthorizedException(['I need to be logged in']);
+      throw new UnauthorizedException([
+        ERRORS_UNAUTHORIZED.YOU_NEED_TO_BE_LOGGED_IN,
+      ]);
     }
 
     const updatedMember = await this.memberRepository.findByLogin(

--- a/new-api/src/v2/modules/members/services/auth.service.ts
+++ b/new-api/src/v2/modules/members/services/auth.service.ts
@@ -7,6 +7,7 @@ import {
 import { JwtService } from '@nestjs/jwt';
 import { InjectRepository } from '@nestjs/typeorm';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
+import { ERRORS_NOT_FOUND } from '@utils/Errors/NotFound';
 import { ERRORS_UNAUTHORIZED } from '@utils/Errors/Unauthorized';
 import { IResetPasswordMemberDTO } from '../dtos/auth/IResetPasswordMember.dto';
 import { ILoginDTO } from '../dtos/ILogin.dto';
@@ -126,7 +127,7 @@ export class ServiceAuth {
 
     if (!updatedMember) {
       throw new NotFoundException([
-        `Not found member with login "${updatedMemberLogin}""`,
+        `${ERRORS_NOT_FOUND.NOT_FOUND_LOGIN} "${updatedMemberLogin}"`,
       ]);
     }
 

--- a/new-api/src/v2/modules/members/services/auth.service.ts
+++ b/new-api/src/v2/modules/members/services/auth.service.ts
@@ -83,14 +83,16 @@ export class ServiceAuth {
       oldToken,
     );
 
+    const messagesError = ['oldToken is not valid'];
+
     if (!isValidToken) {
-      throw new UnauthorizedException();
+      throw new UnauthorizedException(messagesError);
     }
 
     const member = await this.memberRepository.findByLogin(isValidToken.login);
 
     if (!member) {
-      throw new UnauthorizedException();
+      throw new UnauthorizedException(messagesError);
     }
 
     const newToken = (await this.login(member)).auth;

--- a/new-api/src/v2/modules/members/services/auth/resetPasswordMember.service.ts
+++ b/new-api/src/v2/modules/members/services/auth/resetPasswordMember.service.ts
@@ -7,6 +7,7 @@ import {
 } from '@nestjs/common';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import { ERRORS_FORBIDDEN } from '@utils/Errors/Forbidden';
+import { ERRORS_UNPROCESSABLE_ENTITY } from '@utils/Errors/UnprocessableEntity';
 
 interface IRequest {
   repository: IRepositoryMember;
@@ -29,7 +30,7 @@ const resetPassword = async ({
 
   if (!process.env.PASSWORD_DEFAULT_MEMBERS) {
     throw new UnprocessableEntityException([
-      "Member's default password not defined",
+      ERRORS_UNPROCESSABLE_ENTITY.DEFAULT_PASSWORD_NOT_DEFINED,
     ]);
   }
 

--- a/new-api/src/v2/modules/members/services/auth/resetPasswordMember.service.ts
+++ b/new-api/src/v2/modules/members/services/auth/resetPasswordMember.service.ts
@@ -6,6 +6,7 @@ import {
   UnprocessableEntityException,
 } from '@nestjs/common';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
+import { ERRORS_FORBIDDEN } from '@utils/Errors/Forbidden';
 
 interface IRequest {
   repository: IRepositoryMember;
@@ -22,7 +23,7 @@ const resetPassword = async ({
 }: IRequest): Promise<EntityMember> => {
   if (!hasCreatePermission(loggedMember.patent.id)) {
     throw new ForbiddenException([
-      "Your patent don't have permission for updating patent of the member",
+      ERRORS_FORBIDDEN.PATENT_DONT_HAVE_PERMISSION_FOR_UPDATE_MEMBER,
     ]);
   }
 

--- a/new-api/src/v2/modules/members/services/auth/resetPasswordMember.service.ts
+++ b/new-api/src/v2/modules/members/services/auth/resetPasswordMember.service.ts
@@ -22,7 +22,7 @@ const resetPassword = async ({
 }: IRequest): Promise<EntityMember> => {
   if (!hasCreatePermission(loggedMember.patent.id)) {
     throw new ForbiddenException([
-      'Your patent not have permission for updating patent of the member',
+      "Your patent don't have permission for updating patent of the member",
     ]);
   }
 

--- a/new-api/src/v2/modules/members/services/member.service.ts
+++ b/new-api/src/v2/modules/members/services/member.service.ts
@@ -43,7 +43,10 @@ export class ServiceMember {
   public async createMember(
     data: ICreateMemberBasicDataDTO,
   ): Promise<EntityMember> {
+    const memberLogged = await this.getMemberLoggedIn(data.idMemberLogged);
+
     return memberServices.create({
+      memberLogged,
       data: data,
       repositoryMember: this.memberRepository,
       repositoryPatent: this.patentRepository,
@@ -100,7 +103,7 @@ export class ServiceMember {
 
     if (!newPatent) {
       throw new NotFoundException([
-        `Not found patent with id "${newPatentId}""`,
+        `Not found patent with id "${newPatentId}"`,
       ]);
     }
 

--- a/new-api/src/v2/modules/members/services/member.service.ts
+++ b/new-api/src/v2/modules/members/services/member.service.ts
@@ -75,9 +75,11 @@ export class ServiceMember {
     idMember,
     fileName,
   }: IUpdateAvatarMemberDTO): Promise<EntityMember> {
+    const loggedMember = await this.getMemberLoggedIn(idMember);
+
     return memberServices.updateAvatar({
       repository: this.memberRepository,
-      id: idMember,
+      loggedMember,
       fileName,
       storageProvider: this.storageProvider,
     });

--- a/new-api/src/v2/modules/members/services/member.service.ts
+++ b/new-api/src/v2/modules/members/services/member.service.ts
@@ -148,10 +148,15 @@ export class ServiceMember {
     idMemberLogged,
     idMemberToDelete,
   }: IDeleteMemberDTO): Promise<void> {
-    const member = await this.memberRepository.findById(idMemberLogged);
+    let member: EntityMember | undefined;
 
-    if (!member) {
-      throw new UnauthorizedException(['I need to be logged in']);
+    try {
+      member = await this.findById(idMemberLogged);
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw new UnauthorizedException(["You aren't valid member"]);
+      }
+      throw error;
     }
 
     await memberServices.remove({

--- a/new-api/src/v2/modules/members/services/member.service.ts
+++ b/new-api/src/v2/modules/members/services/member.service.ts
@@ -8,6 +8,7 @@ import {
 import { InjectRepository } from '@nestjs/typeorm';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
+import { ERRORS_UNAUTHORIZED } from '@utils/Errors/Unauthorized';
 import { ICreateMemberBasicDataDTO } from '../dtos/ICreateMember.dto';
 import IDeleteMemberDTO from '../dtos/IDeleteMember.dto';
 import IOrderByMember, {
@@ -169,7 +170,7 @@ export class ServiceMember {
     } catch (error) {
       if (error instanceof NotFoundException) {
         throw new UnauthorizedException([
-          'It should be logged in with a valid member',
+          ERRORS_UNAUTHORIZED.YOU_NEED_TO_BE_LOGGED_IN,
         ]);
       }
       throw error;

--- a/new-api/src/v2/modules/members/services/member.service.ts
+++ b/new-api/src/v2/modules/members/services/member.service.ts
@@ -1,4 +1,5 @@
 import {
+  BadRequestException,
   Inject,
   Injectable,
   NotFoundException,
@@ -95,19 +96,19 @@ export class ServiceMember {
 
     if (!updatedMember) {
       throw new NotFoundException([
-        `Not found member with login "${updatedMemberLogin}""`,
+        `Not found member with login "${updatedMemberLogin}"`,
       ]);
     }
 
     const newPatent = await this.patentRepository.findById(newPatentId);
 
     if (!newPatent) {
-      throw new NotFoundException([
+      throw new BadRequestException([
         `Not found patent with id "${newPatentId}"`,
       ]);
     }
 
-    return memberServices.updatePatent({
+    return await memberServices.updatePatent({
       loggedMember,
       newPatent,
       updatedMember,

--- a/new-api/src/v2/modules/members/services/member.service.ts
+++ b/new-api/src/v2/modules/members/services/member.service.ts
@@ -59,11 +59,11 @@ export class ServiceMember {
     idMember,
     newMemberData,
   }: IUpdateMemberDTO): Promise<EntityMember> {
+    const loggedMember = await this.getMemberLoggedIn(idMember);
+
     const member = await memberServices.update({
-      newMemberData: {
-        ...newMemberData,
-        id: idMember,
-      },
+      newMemberData,
+      loggedMember,
       repository: this.memberRepository,
       hashProvider: this.hashProvider,
     });

--- a/new-api/src/v2/modules/members/services/member/createMember.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/createMember.service.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '@nestjs/common';
 import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
+import FakeStorageProvider from '@providers/StorageProvider/implementations/fakes/FakeStorage.provider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 import { ServiceMember } from '../member.service';
 
@@ -22,7 +23,7 @@ const FakeHashProviderMock = FakeHashProvider as jest.Mock<FakeHashProvider>;
 
 let fakeHashProviderMock: IHashProvider;
 
-let iStorageProver: IStorageProvider;
+let fakeStorageProvider: IStorageProvider;
 
 let serviceMember: ServiceMember;
 
@@ -32,12 +33,13 @@ describe('Create Member  - SERVICES', () => {
     fakeRepositoryMember = new FakeRepositoryMember();
 
     fakeHashProviderMock = new FakeHashProviderMock() as jest.Mocked<FakeHashProvider>;
+    fakeStorageProvider = new FakeStorageProvider();
 
     serviceMember = new ServiceMember(
       fakeRepositoryMember,
       fakeRepositoryPatent,
       fakeHashProviderMock,
-      iStorageProver,
+      fakeStorageProvider,
     );
   });
 

--- a/new-api/src/v2/modules/members/services/member/createMember.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/createMember.service.spec.ts
@@ -1,0 +1,309 @@
+import MembersMock from '@modules/members/mocks/member.mock';
+import { FakeRepositoryMember } from '@modules/members/repositories/fakes/Member.fakeRepository';
+import { FakeRepositoryPatent } from '@modules/members/repositories/fakes/Patent.fakeRepository';
+import { EntityMember } from '@modules/members/typeorm/entities/member.entity';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
+import IHashProvider from '@providers/HashProvider/models/IHashProvider';
+import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
+import { ServiceMember } from '../member.service';
+
+let fakeRepositoryPatent: FakeRepositoryPatent;
+let fakeRepositoryMember: FakeRepositoryMember;
+
+let fakeHashProvider: IHashProvider;
+let fakeStorageProver: IStorageProvider;
+
+let serviceMember: ServiceMember;
+
+describe('Create Member  - SERVICES', () => {
+  beforeEach(() => {
+    fakeRepositoryPatent = new FakeRepositoryPatent();
+    fakeRepositoryMember = new FakeRepositoryMember();
+    fakeHashProvider = new FakeHashProvider();
+    serviceMember = new ServiceMember(
+      fakeRepositoryMember,
+      fakeRepositoryPatent,
+      fakeHashProvider,
+      fakeStorageProver,
+    );
+  });
+
+  describe('successful cases', () => {
+    it('should create a new member when basic datas is valid and the member logged in is ADMINISTRATOR', async () => {
+      const memberLoggedIn = await MembersMock.giveAMeAValidMember({
+        patentName: 'ADMINISTRATOR',
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const validPatentMocked = await fakeRepositoryPatent.createSave({
+        name: 'Patent Mocked',
+      });
+
+      const data = {
+        email: 'john_doe@mock.test',
+        name: 'John Doe',
+        patentId: validPatentMocked.id,
+      };
+
+      const memberCreated = await serviceMember.createMember({
+        ...data,
+        idMemberLogged: memberLoggedIn.id,
+      });
+
+      expect(memberCreated).toBeInstanceOf(EntityMember);
+      expect(memberCreated.id).toBeDefined();
+      expect(memberCreated.email).toBe(data.email);
+      expect(memberCreated.name).toBe(data.name);
+      expect(memberCreated.login).toBe(data.email.split('@')[0]);
+      expect(memberCreated.patent.name).toBe(validPatentMocked.name);
+    });
+
+    it('should create a new member when basic datas is valid and the member logged in is ADVISOR', async () => {
+      const memberLoggedIn = await MembersMock.giveAMeAValidMember({
+        patentName: 'ADVISOR',
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const validPatentMocked = await fakeRepositoryPatent.createSave({
+        name: 'Patent Mocked',
+      });
+
+      const data = {
+        email: 'john_doe@mock.test',
+        name: 'John Doe',
+        patentId: validPatentMocked.id,
+      };
+
+      const memberCreated = await serviceMember.createMember({
+        ...data,
+        idMemberLogged: memberLoggedIn.id,
+      });
+
+      expect(memberCreated).toBeInstanceOf(EntityMember);
+      expect(memberCreated.id).toBeDefined();
+      expect(memberCreated.email).toBe(data.email);
+      expect(memberCreated.name).toBe(data.name);
+      expect(memberCreated.login).toBe(data.email.split('@')[0]);
+      expect(memberCreated.patent.name).toBe(validPatentMocked.name);
+    });
+
+    it('should create a new member when basic datas is valid and the member logged in is COORDINATOR', async () => {
+      const memberLoggedIn = await MembersMock.giveAMeAValidMember({
+        patentName: 'COORDINATOR',
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const validPatentMocked = await fakeRepositoryPatent.createSave({
+        name: 'Patent Mocked',
+      });
+
+      const data = {
+        email: 'john_doe@mock.test',
+        name: 'John Doe',
+        patentId: validPatentMocked.id,
+      };
+
+      const memberCreated = await serviceMember.createMember({
+        ...data,
+        idMemberLogged: memberLoggedIn.id,
+      });
+
+      expect(memberCreated).toBeInstanceOf(EntityMember);
+      expect(memberCreated.id).toBeDefined();
+      expect(memberCreated.email).toBe(data.email);
+      expect(memberCreated.name).toBe(data.name);
+      expect(memberCreated.login).toBe(data.email.split('@')[0]);
+      expect(memberCreated.patent.name).toBe(validPatentMocked.name);
+    });
+
+    it('should create a new member when basic datas is valid but the email prefix already exists and the member logged in is ADMINISTRATOR', async () => {
+      const memberLoggedIn = await MembersMock.giveAMeAValidMember({
+        patentName: 'ADMINISTRATOR',
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      await MembersMock.giveAMeAValidMember({
+        patentName: 'Any Patent',
+        login: 'john_doe',
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const validPatentMocked = await fakeRepositoryPatent.createSave({
+        name: 'Patent Mocked',
+      });
+
+      const data = {
+        email: 'john_doe@mock.test',
+        name: 'John Doe',
+        patentId: validPatentMocked.id,
+      };
+
+      const memberCreated = await serviceMember.createMember({
+        ...data,
+        idMemberLogged: memberLoggedIn.id,
+      });
+
+      expect(memberCreated).toBeInstanceOf(EntityMember);
+      expect(memberCreated.id).toBeDefined();
+      expect(memberCreated.email).toBe(data.email);
+      expect(memberCreated.name).toBe(data.name);
+      expect(memberCreated.login).toBe(`${data.email.split('@')[0]}_1`);
+      expect(memberCreated.patent.name).toBe(validPatentMocked.name);
+    });
+  });
+
+  describe('failure cases', () => {
+    it('Should return UNAUTHORIZED when not the member logged in exists', async () => {
+      const validPatentMocked = await fakeRepositoryPatent.createSave({
+        name: 'Patent Mocked',
+      });
+
+      const data = {
+        email: 'john_doe@mock.test',
+        name: 'John Doe',
+        patentId: validPatentMocked.id,
+      };
+
+      let error;
+      let membersNoCreated = undefined;
+
+      try {
+        membersNoCreated = await serviceMember.createMember({
+          ...data,
+          idMemberLogged: "id member doesn't exists",
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(membersNoCreated).toBe(undefined);
+      expect(error).toBeInstanceOf(UnauthorizedException);
+      expect(error.response.message).toStrictEqual([
+        `It should be logged in with a valid member`,
+      ]);
+    });
+
+    it('Should return FORBIDDEN when the member that is logged in is different from: ADMINISTRATOR; ADVISOR; COORDINATOR', async () => {
+      const memberLoggedIn = await MembersMock.giveAMeAValidMember({
+        patentName: 'Patent without permission',
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const validPatentMocked = await fakeRepositoryPatent.createSave({
+        name: 'Patent Mocked',
+      });
+
+      const data = {
+        email: 'john_doe@mock.test',
+        name: 'John Doe',
+        patentId: validPatentMocked.id,
+      };
+
+      let error;
+      let membersNoCreated = undefined;
+      try {
+        membersNoCreated = await serviceMember.createMember({
+          ...data,
+          idMemberLogged: memberLoggedIn.id,
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(membersNoCreated).toBe(undefined);
+      expect(error).toBeInstanceOf(ForbiddenException);
+      expect(error.response.message).toStrictEqual([
+        `Your patent don't have permission for creating a new member`,
+      ]);
+    });
+
+    it("Should return CONFLICT when the member's mail already exists", async () => {
+      const memberLoggedIn = await MembersMock.giveAMeAValidMember({
+        patentName: 'ADMINISTRATOR',
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const email = 'conflic.mail@test.com';
+
+      await MembersMock.giveAMeAValidMember({
+        patentName: 'Any Patent',
+        email,
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const validPatentMocked = await fakeRepositoryPatent.createSave({
+        name: 'Patent Mocked',
+      });
+
+      const data = {
+        email,
+        name: 'John Doe',
+        patentId: validPatentMocked.id,
+      };
+
+      let error;
+      let membersNoCreated = undefined;
+      try {
+        membersNoCreated = await serviceMember.createMember({
+          ...data,
+          idMemberLogged: memberLoggedIn.id,
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(membersNoCreated).toBe(undefined);
+      expect(error).toBeInstanceOf(ConflictException);
+      expect(error.response.message).toStrictEqual([
+        `The email "${email}" already exists`,
+      ]);
+    });
+
+    it("Should return BAD_REQUEST when the patent's id doesn't exist", async () => {
+      const memberLoggedIn = await MembersMock.giveAMeAValidMember({
+        patentName: 'ADMINISTRATOR',
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const patentId = "id patent doesn't exists";
+
+      const data = {
+        email: 'john_doe@mock.test',
+        name: 'John Doe',
+        patentId,
+      };
+
+      let error;
+      let membersNoCreated = undefined;
+      try {
+        membersNoCreated = await serviceMember.createMember({
+          ...data,
+          idMemberLogged: memberLoggedIn.id,
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(membersNoCreated).toBe(undefined);
+      expect(error).toBeInstanceOf(BadRequestException);
+      expect(error.response.message).toStrictEqual([
+        `Not found patent with id "${patentId}"`,
+      ]);
+    });
+  });
+});

--- a/new-api/src/v2/modules/members/services/member/createMember.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/createMember.service.spec.ts
@@ -12,6 +12,7 @@ import FakeHashProvider from '@providers/HashProvider/implementations/fakes/Fake
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import FakeStorageProvider from '@providers/StorageProvider/implementations/fakes/FakeStorage.provider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
+import { ERRORS_UNAUTHORIZED } from '@utils/Errors/Unauthorized';
 import { ServiceMember } from '../member.service';
 
 jest.mock('@providers/HashProvider/implementations/fakes/FakeHashProvider');
@@ -203,7 +204,7 @@ describe('Create Member  - SERVICES', () => {
       expect(membersNoCreated).toBe(undefined);
       expect(error).toBeInstanceOf(UnauthorizedException);
       expect(error.response.message).toStrictEqual([
-        `It should be logged in with a valid member`,
+        ERRORS_UNAUTHORIZED.YOU_NEED_TO_BE_LOGGED_IN,
       ]);
       expect(fakeHashProviderMock.generateHash).toHaveBeenCalledTimes(0);
     });

--- a/new-api/src/v2/modules/members/services/member/createMember.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/createMember.service.spec.ts
@@ -12,6 +12,7 @@ import FakeHashProvider from '@providers/HashProvider/implementations/fakes/Fake
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import FakeStorageProvider from '@providers/StorageProvider/implementations/fakes/FakeStorage.provider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
+import { ERRORS_FORBIDDEN } from '@utils/Errors/Forbidden';
 import { ERRORS_UNAUTHORIZED } from '@utils/Errors/Unauthorized';
 import { ServiceMember } from '../member.service';
 
@@ -240,7 +241,7 @@ describe('Create Member  - SERVICES', () => {
       expect(membersNoCreated).toBe(undefined);
       expect(error).toBeInstanceOf(ForbiddenException);
       expect(error.response.message).toStrictEqual([
-        `Your patent don't have permission for creating a new member`,
+        ERRORS_FORBIDDEN.PATENT_DONT_HAVE_PERMISSION_FOR_CREATE_MEMBER,
       ]);
       expect(fakeHashProviderMock.generateHash).toHaveBeenCalledTimes(0);
     });

--- a/new-api/src/v2/modules/members/services/member/createMember.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/createMember.service.spec.ts
@@ -13,11 +13,16 @@ import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 import { ServiceMember } from '../member.service';
 
+jest.mock('@providers/HashProvider/implementations/fakes/FakeHashProvider');
+
 let fakeRepositoryPatent: FakeRepositoryPatent;
 let fakeRepositoryMember: FakeRepositoryMember;
 
-let fakeHashProvider: IHashProvider;
-let fakeStorageProver: IStorageProvider;
+const FakeHashProviderMock = FakeHashProvider as jest.Mock<FakeHashProvider>;
+
+let fakeHashProviderMock: IHashProvider;
+
+let iStorageProver: IStorageProvider;
 
 let serviceMember: ServiceMember;
 
@@ -25,12 +30,14 @@ describe('Create Member  - SERVICES', () => {
   beforeEach(() => {
     fakeRepositoryPatent = new FakeRepositoryPatent();
     fakeRepositoryMember = new FakeRepositoryMember();
-    fakeHashProvider = new FakeHashProvider();
+
+    fakeHashProviderMock = new FakeHashProviderMock() as jest.Mocked<FakeHashProvider>;
+
     serviceMember = new ServiceMember(
       fakeRepositoryMember,
       fakeRepositoryPatent,
-      fakeHashProvider,
-      fakeStorageProver,
+      fakeHashProviderMock,
+      iStorageProver,
     );
   });
 
@@ -63,6 +70,7 @@ describe('Create Member  - SERVICES', () => {
       expect(memberCreated.name).toBe(data.name);
       expect(memberCreated.login).toBe(data.email.split('@')[0]);
       expect(memberCreated.patent.name).toBe(validPatentMocked.name);
+      expect(fakeHashProviderMock.generateHash).toHaveBeenCalledTimes(1);
     });
 
     it('should create a new member when basic datas is valid and the member logged in is ADVISOR', async () => {
@@ -93,6 +101,7 @@ describe('Create Member  - SERVICES', () => {
       expect(memberCreated.name).toBe(data.name);
       expect(memberCreated.login).toBe(data.email.split('@')[0]);
       expect(memberCreated.patent.name).toBe(validPatentMocked.name);
+      expect(fakeHashProviderMock.generateHash).toHaveBeenCalledTimes(1);
     });
 
     it('should create a new member when basic datas is valid and the member logged in is COORDINATOR', async () => {
@@ -123,6 +132,7 @@ describe('Create Member  - SERVICES', () => {
       expect(memberCreated.name).toBe(data.name);
       expect(memberCreated.login).toBe(data.email.split('@')[0]);
       expect(memberCreated.patent.name).toBe(validPatentMocked.name);
+      expect(fakeHashProviderMock.generateHash).toHaveBeenCalledTimes(1);
     });
 
     it('should create a new member when basic datas is valid but the email prefix already exists and the member logged in is ADMINISTRATOR', async () => {
@@ -160,6 +170,7 @@ describe('Create Member  - SERVICES', () => {
       expect(memberCreated.name).toBe(data.name);
       expect(memberCreated.login).toBe(`${data.email.split('@')[0]}_1`);
       expect(memberCreated.patent.name).toBe(validPatentMocked.name);
+      expect(fakeHashProviderMock.generateHash).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -192,6 +203,7 @@ describe('Create Member  - SERVICES', () => {
       expect(error.response.message).toStrictEqual([
         `It should be logged in with a valid member`,
       ]);
+      expect(fakeHashProviderMock.generateHash).toHaveBeenCalledTimes(0);
     });
 
     it('Should return FORBIDDEN when the member that is logged in is different from: ADMINISTRATOR; ADVISOR; COORDINATOR', async () => {
@@ -227,6 +239,7 @@ describe('Create Member  - SERVICES', () => {
       expect(error.response.message).toStrictEqual([
         `Your patent don't have permission for creating a new member`,
       ]);
+      expect(fakeHashProviderMock.generateHash).toHaveBeenCalledTimes(0);
     });
 
     it("Should return CONFLICT when the member's mail already exists", async () => {
@@ -271,6 +284,7 @@ describe('Create Member  - SERVICES', () => {
       expect(error.response.message).toStrictEqual([
         `The email "${email}" already exists`,
       ]);
+      expect(fakeHashProviderMock.generateHash).toHaveBeenCalledTimes(0);
     });
 
     it("Should return BAD_REQUEST when the patent's id doesn't exist", async () => {
@@ -304,6 +318,7 @@ describe('Create Member  - SERVICES', () => {
       expect(error.response.message).toStrictEqual([
         `Not found patent with id "${patentId}"`,
       ]);
+      expect(fakeHashProviderMock.generateHash).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/new-api/src/v2/modules/members/services/member/createMember.service.ts
+++ b/new-api/src/v2/modules/members/services/member/createMember.service.ts
@@ -9,6 +9,7 @@ import {
   ForbiddenException,
 } from '@nestjs/common';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
+import { ERRORS_FORBIDDEN } from '@utils/Errors/Forbidden';
 
 interface IRequest {
   memberLogged: EntityMember;
@@ -27,7 +28,7 @@ const create = async ({
 }: IRequest): Promise<EntityMember> => {
   if (!hasDeletePermission(memberLogged.patent.id)) {
     throw new ForbiddenException([
-      "Your patent don't have permission for creating a new member",
+      ERRORS_FORBIDDEN.PATENT_DONT_HAVE_PERMISSION_FOR_CREATE_MEMBER,
     ]);
   }
 

--- a/new-api/src/v2/modules/members/services/member/createMember.service.ts
+++ b/new-api/src/v2/modules/members/services/member/createMember.service.ts
@@ -1,30 +1,48 @@
 import { ICreateMemberBasicDataDTO } from '@modules/members/dtos/ICreateMember.dto';
+import { hasDeletePermission } from '@modules/members/enums/CREATION_PERMISSION_PATENTS';
 import IRepositoryMember from '@modules/members/repositories/IRepositoryMember';
 import IRepositoryPatent from '@modules/members/repositories/IRepositoryPatent';
 import { EntityMember } from '@modules/members/typeorm/entities/member.entity';
-import { BadRequestException, ConflictException } from '@nestjs/common';
+import {
+  BadRequestException,
+  ConflictException,
+  ForbiddenException,
+} from '@nestjs/common';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 
 interface IRequest {
+  memberLogged: EntityMember;
   data: ICreateMemberBasicDataDTO;
   repositoryMember: IRepositoryMember;
   repositoryPatent: IRepositoryPatent;
   hashProvider: IHashProvider;
 }
 
-const create = async (params: IRequest): Promise<EntityMember> => {
-  const { repositoryMember, repositoryPatent, hashProvider, data } = params;
+const create = async ({
+  repositoryMember,
+  repositoryPatent,
+  hashProvider,
+  data,
+  memberLogged,
+}: IRequest): Promise<EntityMember> => {
+  if (!hasDeletePermission(memberLogged.patent.id)) {
+    throw new ForbiddenException([
+      "Your patent don't have permission for creating a new member",
+    ]);
+  }
 
   const emailExists = await repositoryMember.findByEmail(data.email);
 
   if (emailExists) {
-    throw new ConflictException('Email already exists');
+    throw new ConflictException([`The email "${data.email}" already exists`]);
   }
 
   const patent = await repositoryPatent.findById(data.patentId);
 
   if (!patent) {
-    throw new BadRequestException('Patent not found');
+    throw new BadRequestException([
+      `Not found patent with id "${data.patentId}"`,
+    ]);
   }
 
   const login = await createLogin(data.email, repositoryMember);
@@ -49,6 +67,7 @@ const createLogin = async (
   let login = preLogin;
   const [members, quantity] = await repositoryMember.countLogin(login);
 
+  // TODO: It should refactor this code
   if (quantity > 0) {
     let existsLogin: EntityMember | undefined;
     let count = quantity;

--- a/new-api/src/v2/modules/members/services/member/deleteMember.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/deleteMember.service.spec.ts
@@ -7,6 +7,7 @@ import FakeHashProvider from '@providers/HashProvider/implementations/fakes/Fake
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import FakeStorageProvider from '@providers/StorageProvider/implementations/fakes/FakeStorage.provider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
+import { ERRORS_UNAUTHORIZED } from '@utils/Errors/Unauthorized';
 import { ServiceMember } from '../member.service';
 
 let fakeRepositoryPatent: FakeRepositoryPatent;
@@ -136,7 +137,7 @@ describe('Delete Member  - SERVICES', () => {
       expect(memberNoDeleted).toBeInstanceOf(EntityMember);
       expect(error).toBeInstanceOf(UnauthorizedException);
       expect(error.response.message).toStrictEqual([
-        `It should be logged in with a valid member`,
+        ERRORS_UNAUTHORIZED.YOU_NEED_TO_BE_LOGGED_IN,
       ]);
     });
 

--- a/new-api/src/v2/modules/members/services/member/deleteMember.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/deleteMember.service.spec.ts
@@ -3,6 +3,7 @@ import { FakeRepositoryMember } from '@modules/members/repositories/fakes/Member
 import { FakeRepositoryPatent } from '@modules/members/repositories/fakes/Patent.fakeRepository';
 import { EntityMember } from '@modules/members/typeorm/entities/member.entity';
 import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
+import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 import { ServiceMember } from '../member.service';
@@ -10,7 +11,7 @@ import { ServiceMember } from '../member.service';
 let fakeRepositoryPatent: FakeRepositoryPatent;
 let fakeRepositoryMember: FakeRepositoryMember;
 
-let iHashProvider: IHashProvider;
+let fakeHashProvider: IHashProvider;
 let iStorageProver: IStorageProvider;
 
 let serviceMember: ServiceMember;
@@ -19,10 +20,11 @@ describe('Delete Member  - SERVICES', () => {
   beforeEach(() => {
     fakeRepositoryPatent = new FakeRepositoryPatent();
     fakeRepositoryMember = new FakeRepositoryMember();
+    fakeHashProvider = new FakeHashProvider();
     serviceMember = new ServiceMember(
       fakeRepositoryMember,
       fakeRepositoryPatent,
-      iHashProvider,
+      fakeHashProvider,
       iStorageProver,
     );
   });

--- a/new-api/src/v2/modules/members/services/member/deleteMember.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/deleteMember.service.spec.ts
@@ -7,6 +7,7 @@ import FakeHashProvider from '@providers/HashProvider/implementations/fakes/Fake
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import FakeStorageProvider from '@providers/StorageProvider/implementations/fakes/FakeStorage.provider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
+import { ERRORS_FORBIDDEN } from '@utils/Errors/Forbidden';
 import { ERRORS_UNAUTHORIZED } from '@utils/Errors/Unauthorized';
 import { ServiceMember } from '../member.service';
 
@@ -172,7 +173,7 @@ describe('Delete Member  - SERVICES', () => {
       expect(memberNoDeleted).toBeInstanceOf(EntityMember);
       expect(error).toBeInstanceOf(ForbiddenException);
       expect(error.response.message).toStrictEqual([
-        `Your patent don't have permission for deleting a member`,
+        ERRORS_FORBIDDEN.PATENT_DONT_HAVE_PERMISSION_FOR_DELETE_MEMBER,
       ]);
     });
   });

--- a/new-api/src/v2/modules/members/services/member/deleteMember.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/deleteMember.service.spec.ts
@@ -5,6 +5,7 @@ import { EntityMember } from '@modules/members/typeorm/entities/member.entity';
 import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
 import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
+import FakeStorageProvider from '@providers/StorageProvider/implementations/fakes/FakeStorage.provider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 import { ServiceMember } from '../member.service';
 
@@ -12,7 +13,7 @@ let fakeRepositoryPatent: FakeRepositoryPatent;
 let fakeRepositoryMember: FakeRepositoryMember;
 
 let fakeHashProvider: IHashProvider;
-let iStorageProver: IStorageProvider;
+let fakeStorageProvider: IStorageProvider;
 
 let serviceMember: ServiceMember;
 
@@ -20,12 +21,15 @@ describe('Delete Member  - SERVICES', () => {
   beforeEach(() => {
     fakeRepositoryPatent = new FakeRepositoryPatent();
     fakeRepositoryMember = new FakeRepositoryMember();
+
     fakeHashProvider = new FakeHashProvider();
+    fakeStorageProvider = new FakeStorageProvider();
+
     serviceMember = new ServiceMember(
       fakeRepositoryMember,
       fakeRepositoryPatent,
       fakeHashProvider,
-      iStorageProver,
+      fakeStorageProvider,
     );
   });
 

--- a/new-api/src/v2/modules/members/services/member/deleteMember.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/deleteMember.service.spec.ts
@@ -165,7 +165,7 @@ describe('Delete Member  - SERVICES', () => {
       expect(memberNoDeleted).toBeInstanceOf(EntityMember);
       expect(error).toBeInstanceOf(ForbiddenException);
       expect(error.response.message).toStrictEqual([
-        `Your patent not have permission for deleting a member`,
+        `Your patent don't have permission for deleting a member`,
       ]);
     });
   });

--- a/new-api/src/v2/modules/members/services/member/deleteMember.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/deleteMember.service.spec.ts
@@ -2,11 +2,7 @@ import MembersMock from '@modules/members/mocks/member.mock';
 import { FakeRepositoryMember } from '@modules/members/repositories/fakes/Member.fakeRepository';
 import { FakeRepositoryPatent } from '@modules/members/repositories/fakes/Patent.fakeRepository';
 import { EntityMember } from '@modules/members/typeorm/entities/member.entity';
-import {
-  ForbiddenException,
-  NotFoundException,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { ForbiddenException, UnauthorizedException } from '@nestjs/common';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 import { ServiceMember } from '../member.service';
@@ -133,7 +129,9 @@ describe('Delete Member  - SERVICES', () => {
 
       expect(memberNoDeleted).toBeInstanceOf(EntityMember);
       expect(error).toBeInstanceOf(UnauthorizedException);
-      expect(error.response.message).toStrictEqual([`You aren't valid member`]);
+      expect(error.response.message).toStrictEqual([
+        `It should be logged in with a valid member`,
+      ]);
     });
 
     it('Should return FORBIDDEN when the member that is logged in is different from: ADMINISTRATOR; ADVISOR; COORDINATOR', async () => {

--- a/new-api/src/v2/modules/members/services/member/deleteMember.service.ts
+++ b/new-api/src/v2/modules/members/services/member/deleteMember.service.ts
@@ -16,7 +16,7 @@ const deleteById = async ({
 }: IRequest): Promise<void> => {
   if (!hasDeletePermission(member.patent.id)) {
     throw new ForbiddenException([
-      'Your patent not have permission for deleting a member',
+      "Your patent don't have permission for deleting a member",
     ]);
   }
 

--- a/new-api/src/v2/modules/members/services/member/deleteMember.service.ts
+++ b/new-api/src/v2/modules/members/services/member/deleteMember.service.ts
@@ -3,6 +3,7 @@ import { hasDeletePermission } from '@modules/members/enums/CREATION_PERMISSION_
 import IRepositoryMember from '@modules/members/repositories/IRepositoryMember';
 import { EntityMember } from '@modules/members/typeorm/entities/member.entity';
 import { ForbiddenException } from '@nestjs/common';
+import { ERRORS_FORBIDDEN } from '@utils/Errors/Forbidden';
 
 interface IRequest extends Omit<IDeleteMemberDTO, 'idMemberLogged'> {
   repository: IRepositoryMember;
@@ -16,7 +17,7 @@ const deleteById = async ({
 }: IRequest): Promise<void> => {
   if (!hasDeletePermission(member.patent.id)) {
     throw new ForbiddenException([
-      "Your patent don't have permission for deleting a member",
+      ERRORS_FORBIDDEN.PATENT_DONT_HAVE_PERMISSION_FOR_DELETE_MEMBER,
     ]);
   }
 

--- a/new-api/src/v2/modules/members/services/member/findAllMember.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/findAllMember.service.spec.ts
@@ -1,0 +1,57 @@
+import MembersMock from '@modules/members/mocks/member.mock';
+import { FakeRepositoryMember } from '@modules/members/repositories/fakes/Member.fakeRepository';
+import { FakeRepositoryPatent } from '@modules/members/repositories/fakes/Patent.fakeRepository';
+import IHashProvider from '@providers/HashProvider/models/IHashProvider';
+import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
+import NoContentException from '../../../../utils/Exceptions/NoContent.exception';
+import { ServiceMember } from '../member.service';
+import { ServicePatent } from '../patent.service';
+
+let fakeRepositoryPatent: FakeRepositoryPatent;
+let fakeRepositoryMember: FakeRepositoryMember;
+
+let iHashProvider: IHashProvider;
+let iStorageProver: IStorageProvider;
+
+let serviceMember: ServiceMember;
+
+describe('Find all Members - SERVICES', () => {
+  beforeEach(() => {
+    fakeRepositoryPatent = new FakeRepositoryPatent();
+    fakeRepositoryMember = new FakeRepositoryMember();
+    serviceMember = new ServiceMember(
+      fakeRepositoryMember,
+      fakeRepositoryPatent,
+      iHashProvider,
+      iStorageProver,
+    );
+  });
+
+  describe('successful cases', () => {
+    it('should return a list of members when at least one members exist', async () => {
+      const member = await MembersMock.giveAMeAValidMember({
+        patentName: 'COORDINATOR',
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const member2 = await MembersMock.giveAMeAValidMember({
+        patentName: 'ADVISOR',
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const result = await serviceMember.findAll({});
+
+      expect(result.length).toBe(2);
+      expect(result[0].patent).toBe(member.patent);
+      expect(result[1].patent).toBe(member2.patent);
+    });
+
+    it('should return NO_CONTENT when no patent exists', async () => {
+      await expect(serviceMember.findAll({})).rejects.toBeInstanceOf(
+        NoContentException,
+      );
+    });
+  });
+});

--- a/new-api/src/v2/modules/members/services/member/findAllMember.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/findAllMember.service.spec.ts
@@ -5,7 +5,6 @@ import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 import NoContentException from '../../../../utils/Exceptions/NoContent.exception';
 import { ServiceMember } from '../member.service';
-import { ServicePatent } from '../patent.service';
 
 let fakeRepositoryPatent: FakeRepositoryPatent;
 let fakeRepositoryMember: FakeRepositoryMember;

--- a/new-api/src/v2/modules/members/services/member/findAllMember.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/findAllMember.service.spec.ts
@@ -3,6 +3,7 @@ import { FakeRepositoryMember } from '@modules/members/repositories/fakes/Member
 import { FakeRepositoryPatent } from '@modules/members/repositories/fakes/Patent.fakeRepository';
 import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
+import FakeStorageProvider from '@providers/StorageProvider/implementations/fakes/FakeStorage.provider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 import NoContentException from '../../../../utils/Exceptions/NoContent.exception';
 import { ServiceMember } from '../member.service';
@@ -11,7 +12,7 @@ let fakeRepositoryPatent: FakeRepositoryPatent;
 let fakeRepositoryMember: FakeRepositoryMember;
 
 let fakeHashProvider: IHashProvider;
-let iStorageProver: IStorageProvider;
+let fakeStorageProvider: IStorageProvider;
 
 let serviceMember: ServiceMember;
 
@@ -19,12 +20,15 @@ describe('Find all Members - SERVICES', () => {
   beforeEach(() => {
     fakeRepositoryPatent = new FakeRepositoryPatent();
     fakeRepositoryMember = new FakeRepositoryMember();
+
     fakeHashProvider = new FakeHashProvider();
+    fakeStorageProvider = new FakeStorageProvider();
+
     serviceMember = new ServiceMember(
       fakeRepositoryMember,
       fakeRepositoryPatent,
       fakeHashProvider,
-      iStorageProver,
+      fakeStorageProvider,
     );
   });
 

--- a/new-api/src/v2/modules/members/services/member/findAllMember.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/findAllMember.service.spec.ts
@@ -1,6 +1,7 @@
 import MembersMock from '@modules/members/mocks/member.mock';
 import { FakeRepositoryMember } from '@modules/members/repositories/fakes/Member.fakeRepository';
 import { FakeRepositoryPatent } from '@modules/members/repositories/fakes/Patent.fakeRepository';
+import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 import NoContentException from '../../../../utils/Exceptions/NoContent.exception';
@@ -9,7 +10,7 @@ import { ServiceMember } from '../member.service';
 let fakeRepositoryPatent: FakeRepositoryPatent;
 let fakeRepositoryMember: FakeRepositoryMember;
 
-let iHashProvider: IHashProvider;
+let fakeHashProvider: IHashProvider;
 let iStorageProver: IStorageProvider;
 
 let serviceMember: ServiceMember;
@@ -18,10 +19,11 @@ describe('Find all Members - SERVICES', () => {
   beforeEach(() => {
     fakeRepositoryPatent = new FakeRepositoryPatent();
     fakeRepositoryMember = new FakeRepositoryMember();
+    fakeHashProvider = new FakeHashProvider();
     serviceMember = new ServiceMember(
       fakeRepositoryMember,
       fakeRepositoryPatent,
-      iHashProvider,
+      fakeHashProvider,
       iStorageProver,
     );
   });

--- a/new-api/src/v2/modules/members/services/member/findAllMember.service.ts
+++ b/new-api/src/v2/modules/members/services/member/findAllMember.service.ts
@@ -1,6 +1,7 @@
 import IRepositoryMember from '@modules/members/repositories/IRepositoryMember';
 import { EntityMember } from '@modules/members/typeorm/entities/member.entity';
 import IOrderByMember from '../../dtos/IOrderByMember.dto';
+import NoContentExcepetion from '../../../../utils/Exceptions/NoContent.exception';
 
 interface IRequest {
   repository: IRepositoryMember;
@@ -11,7 +12,12 @@ const findAll = async ({
   repository,
   order,
 }: IRequest): Promise<EntityMember[]> => {
-  return repository.findAll(order);
+  const memebers = await repository.findAll(order);
+
+  if (memebers.length <= 0) {
+    throw new NoContentExcepetion();
+  }
+  return memebers;
 };
 
 export default findAll;

--- a/new-api/src/v2/modules/members/services/member/findMemberByID.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/findMemberByID.service.spec.ts
@@ -3,6 +3,7 @@ import { FakeRepositoryMember } from '@modules/members/repositories/fakes/Member
 import { FakeRepositoryPatent } from '@modules/members/repositories/fakes/Patent.fakeRepository';
 import { EntityMember } from '@modules/members/typeorm/entities/member.entity';
 import { NotFoundException } from '@nestjs/common';
+import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 import { ServiceMember } from '../member.service';
@@ -10,7 +11,7 @@ import { ServiceMember } from '../member.service';
 let fakeRepositoryPatent: FakeRepositoryPatent;
 let fakeRepositoryMember: FakeRepositoryMember;
 
-let iHashProvider: IHashProvider;
+let fakeHashProvider: IHashProvider;
 let iStorageProver: IStorageProvider;
 
 let serviceMember: ServiceMember;
@@ -19,10 +20,11 @@ describe('Find Member by ID  - SERVICES', () => {
   beforeEach(() => {
     fakeRepositoryPatent = new FakeRepositoryPatent();
     fakeRepositoryMember = new FakeRepositoryMember();
+    fakeHashProvider = new FakeHashProvider();
     serviceMember = new ServiceMember(
       fakeRepositoryMember,
       fakeRepositoryPatent,
-      iHashProvider,
+      fakeHashProvider,
       iStorageProver,
     );
   });

--- a/new-api/src/v2/modules/members/services/member/findMemberByID.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/findMemberByID.service.spec.ts
@@ -1,0 +1,61 @@
+import MembersMock from '@modules/members/mocks/member.mock';
+import { FakeRepositoryMember } from '@modules/members/repositories/fakes/Member.fakeRepository';
+import { FakeRepositoryPatent } from '@modules/members/repositories/fakes/Patent.fakeRepository';
+import { EntityMember } from '@modules/members/typeorm/entities/member.entity';
+import { NotFoundException } from '@nestjs/common';
+import IHashProvider from '@providers/HashProvider/models/IHashProvider';
+import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
+import NoContentException from '../../../../utils/Exceptions/NoContent.exception';
+import { ServiceMember } from '../member.service';
+
+let fakeRepositoryPatent: FakeRepositoryPatent;
+let fakeRepositoryMember: FakeRepositoryMember;
+
+let iHashProvider: IHashProvider;
+let iStorageProver: IStorageProvider;
+
+let serviceMember: ServiceMember;
+
+describe('Find Member by ID  - SERVICES', () => {
+  beforeEach(() => {
+    fakeRepositoryPatent = new FakeRepositoryPatent();
+    fakeRepositoryMember = new FakeRepositoryMember();
+    serviceMember = new ServiceMember(
+      fakeRepositoryMember,
+      fakeRepositoryPatent,
+      iHashProvider,
+      iStorageProver,
+    );
+  });
+
+  describe('successful cases', () => {
+    it('should return a member when member id exist', async () => {
+      const member = await MembersMock.giveAMeAValidMember({
+        patentName: 'ADMINISTRATOR',
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const result = await serviceMember.findById(member.id);
+
+      expect(result).toBeInstanceOf(EntityMember);
+      expect(result.id).toBe(member.id);
+    });
+
+    it('should return NOT_FOUNT when no member id exists', async () => {
+      let error;
+      const uuidMocked = 'uuid not exist';
+
+      try {
+        await serviceMember.findById(uuidMocked);
+      } catch (err) {
+        error = err;
+      }
+
+      expect(error).toBeInstanceOf(NotFoundException);
+      expect(error.response.message).toStrictEqual([
+        `Not found member with id "${uuidMocked}"`,
+      ]);
+    });
+  });
+});

--- a/new-api/src/v2/modules/members/services/member/findMemberByID.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/findMemberByID.service.spec.ts
@@ -40,7 +40,8 @@ describe('Find Member by ID  - SERVICES', () => {
       expect(result).toBeInstanceOf(EntityMember);
       expect(result.id).toBe(member.id);
     });
-
+  });
+  describe('failure cases', () => {
     it('should return NOT_FOUNT when no member id exists', async () => {
       let error;
       const uuidMocked = 'uuid not exist';

--- a/new-api/src/v2/modules/members/services/member/findMemberByID.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/findMemberByID.service.spec.ts
@@ -7,6 +7,7 @@ import FakeHashProvider from '@providers/HashProvider/implementations/fakes/Fake
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import FakeStorageProvider from '@providers/StorageProvider/implementations/fakes/FakeStorage.provider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
+import { ERRORS_NOT_FOUND } from '@utils/Errors/NotFound';
 import { ServiceMember } from '../member.service';
 
 let fakeRepositoryPatent: FakeRepositoryPatent;
@@ -60,7 +61,7 @@ describe('Find Member by ID  - SERVICES', () => {
 
       expect(error).toBeInstanceOf(NotFoundException);
       expect(error.response.message).toStrictEqual([
-        `Not found member with id "${uuidMocked}"`,
+        `${ERRORS_NOT_FOUND.NOT_FOUND_LOGIN} "${uuidMocked}"`,
       ]);
     });
   });

--- a/new-api/src/v2/modules/members/services/member/findMemberByID.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/findMemberByID.service.spec.ts
@@ -5,6 +5,7 @@ import { EntityMember } from '@modules/members/typeorm/entities/member.entity';
 import { NotFoundException } from '@nestjs/common';
 import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
+import FakeStorageProvider from '@providers/StorageProvider/implementations/fakes/FakeStorage.provider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 import { ServiceMember } from '../member.service';
 
@@ -12,7 +13,7 @@ let fakeRepositoryPatent: FakeRepositoryPatent;
 let fakeRepositoryMember: FakeRepositoryMember;
 
 let fakeHashProvider: IHashProvider;
-let iStorageProver: IStorageProvider;
+let fakeStorageProvider: IStorageProvider;
 
 let serviceMember: ServiceMember;
 
@@ -20,12 +21,15 @@ describe('Find Member by ID  - SERVICES', () => {
   beforeEach(() => {
     fakeRepositoryPatent = new FakeRepositoryPatent();
     fakeRepositoryMember = new FakeRepositoryMember();
+
     fakeHashProvider = new FakeHashProvider();
+    fakeStorageProvider = new FakeStorageProvider();
+
     serviceMember = new ServiceMember(
       fakeRepositoryMember,
       fakeRepositoryPatent,
       fakeHashProvider,
-      iStorageProver,
+      fakeStorageProvider,
     );
   });
 

--- a/new-api/src/v2/modules/members/services/member/findMemberByID.service.ts
+++ b/new-api/src/v2/modules/members/services/member/findMemberByID.service.ts
@@ -11,10 +11,10 @@ const findById = async ({
   repository,
   id,
 }: IRequest): Promise<EntityMember> => {
-  const member = repository.findById(id);
+  const member = await repository.findById(id);
 
   if (!member) {
-    throw new NotFoundException('Member not exist');
+    throw new NotFoundException([`Not found member with id "${id}"`]);
   }
 
   return member;

--- a/new-api/src/v2/modules/members/services/member/findMemberByID.service.ts
+++ b/new-api/src/v2/modules/members/services/member/findMemberByID.service.ts
@@ -1,6 +1,7 @@
 import IRepositoryMember from '@modules/members/repositories/IRepositoryMember';
 import { EntityMember } from '@modules/members/typeorm/entities/member.entity';
 import { NotFoundException } from '@nestjs/common';
+import { ERRORS_NOT_FOUND } from '@utils/Errors/NotFound';
 
 interface IRequest {
   repository: IRepositoryMember;
@@ -14,7 +15,9 @@ const findById = async ({
   const member = await repository.findById(id);
 
   if (!member) {
-    throw new NotFoundException([`Not found member with id "${id}"`]);
+    throw new NotFoundException([
+      `${ERRORS_NOT_FOUND.NOT_FOUND_LOGIN} "${id}"`,
+    ]);
   }
 
   return member;

--- a/new-api/src/v2/modules/members/services/member/findMemberByLogin.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/findMemberByLogin.service.spec.ts
@@ -40,7 +40,8 @@ describe('Find Member by LOGGIN  - SERVICES', () => {
       expect(result).toBeInstanceOf(EntityMember);
       expect(member.login).toBe(member.login);
     });
-
+  });
+  describe('failure cases', () => {
     it('should return NOT_FOUNT when no member login exists', async () => {
       let error;
       const logginMocked = 'loggin not exist';

--- a/new-api/src/v2/modules/members/services/member/findMemberByLogin.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/findMemberByLogin.service.spec.ts
@@ -7,6 +7,7 @@ import FakeHashProvider from '@providers/HashProvider/implementations/fakes/Fake
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import FakeStorageProvider from '@providers/StorageProvider/implementations/fakes/FakeStorage.provider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
+import { ERRORS_NOT_FOUND } from '@utils/Errors/NotFound';
 import { ServiceMember } from '../member.service';
 
 let fakeRepositoryPatent: FakeRepositoryPatent;
@@ -60,7 +61,7 @@ describe('Find Member by LOGGIN  - SERVICES', () => {
 
       expect(error).toBeInstanceOf(NotFoundException);
       expect(error.response.message).toStrictEqual([
-        `Not found member with loggin "${logginMocked}"`,
+        `${ERRORS_NOT_FOUND.NOT_FOUND_LOGIN} "${logginMocked}"`,
       ]);
     });
   });

--- a/new-api/src/v2/modules/members/services/member/findMemberByLogin.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/findMemberByLogin.service.spec.ts
@@ -5,6 +5,7 @@ import { EntityMember } from '@modules/members/typeorm/entities/member.entity';
 import { NotFoundException } from '@nestjs/common';
 import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
+import FakeStorageProvider from '@providers/StorageProvider/implementations/fakes/FakeStorage.provider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 import { ServiceMember } from '../member.service';
 
@@ -12,7 +13,7 @@ let fakeRepositoryPatent: FakeRepositoryPatent;
 let fakeRepositoryMember: FakeRepositoryMember;
 
 let fakeHashProvider: IHashProvider;
-let iStorageProver: IStorageProvider;
+let fakeStorageProvider: IStorageProvider;
 
 let serviceMember: ServiceMember;
 
@@ -20,12 +21,15 @@ describe('Find Member by LOGGIN  - SERVICES', () => {
   beforeEach(() => {
     fakeRepositoryPatent = new FakeRepositoryPatent();
     fakeRepositoryMember = new FakeRepositoryMember();
+
     fakeHashProvider = new FakeHashProvider();
+    fakeStorageProvider = new FakeStorageProvider();
+
     serviceMember = new ServiceMember(
       fakeRepositoryMember,
       fakeRepositoryPatent,
       fakeHashProvider,
-      iStorageProver,
+      fakeStorageProvider,
     );
   });
 

--- a/new-api/src/v2/modules/members/services/member/findMemberByLogin.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/findMemberByLogin.service.spec.ts
@@ -15,7 +15,7 @@ let iStorageProver: IStorageProvider;
 
 let serviceMember: ServiceMember;
 
-describe('Find Member by ID  - SERVICES', () => {
+describe('Find Member by LOGGIN  - SERVICES', () => {
   beforeEach(() => {
     fakeRepositoryPatent = new FakeRepositoryPatent();
     fakeRepositoryMember = new FakeRepositoryMember();
@@ -28,32 +28,32 @@ describe('Find Member by ID  - SERVICES', () => {
   });
 
   describe('successful cases', () => {
-    it('should return a member when member id exist', async () => {
+    it('should return a member when member login exist', async () => {
       const member = await MembersMock.giveAMeAValidMember({
         patentName: 'ADMINISTRATOR',
         fakeRepositoryMember,
         fakeRepositoryPatent,
       });
 
-      const result = await serviceMember.findById(member.id);
+      const result = await serviceMember.findByLogin(member.login);
 
       expect(result).toBeInstanceOf(EntityMember);
-      expect(result.id).toBe(member.id);
+      expect(member.login).toBe(member.login);
     });
 
-    it('should return NOT_FOUNT when no member id exists', async () => {
+    it('should return NOT_FOUNT when no member login exists', async () => {
       let error;
-      const uuidMocked = 'uuid not exist';
+      const logginMocked = 'loggin not exist';
 
       try {
-        await serviceMember.findById(uuidMocked);
+        await serviceMember.findByLogin(logginMocked);
       } catch (err) {
         error = err;
       }
 
       expect(error).toBeInstanceOf(NotFoundException);
       expect(error.response.message).toStrictEqual([
-        `Not found member with id "${uuidMocked}"`,
+        `Not found member with loggin "${logginMocked}"`,
       ]);
     });
   });

--- a/new-api/src/v2/modules/members/services/member/findMemberByLogin.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/findMemberByLogin.service.spec.ts
@@ -3,6 +3,7 @@ import { FakeRepositoryMember } from '@modules/members/repositories/fakes/Member
 import { FakeRepositoryPatent } from '@modules/members/repositories/fakes/Patent.fakeRepository';
 import { EntityMember } from '@modules/members/typeorm/entities/member.entity';
 import { NotFoundException } from '@nestjs/common';
+import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 import { ServiceMember } from '../member.service';
@@ -10,7 +11,7 @@ import { ServiceMember } from '../member.service';
 let fakeRepositoryPatent: FakeRepositoryPatent;
 let fakeRepositoryMember: FakeRepositoryMember;
 
-let iHashProvider: IHashProvider;
+let fakeHashProvider: IHashProvider;
 let iStorageProver: IStorageProvider;
 
 let serviceMember: ServiceMember;
@@ -19,10 +20,11 @@ describe('Find Member by LOGGIN  - SERVICES', () => {
   beforeEach(() => {
     fakeRepositoryPatent = new FakeRepositoryPatent();
     fakeRepositoryMember = new FakeRepositoryMember();
+    fakeHashProvider = new FakeHashProvider();
     serviceMember = new ServiceMember(
       fakeRepositoryMember,
       fakeRepositoryPatent,
-      iHashProvider,
+      fakeHashProvider,
       iStorageProver,
     );
   });

--- a/new-api/src/v2/modules/members/services/member/findMemberByLogin.service.ts
+++ b/new-api/src/v2/modules/members/services/member/findMemberByLogin.service.ts
@@ -14,7 +14,7 @@ const findByLogin = async ({
   const member = await repository.findByLogin(login);
 
   if (!member) {
-    throw new NotFoundException('Not found Member');
+    throw new NotFoundException([`Not found member with loggin "${login}"`]);
   }
 
   return member;

--- a/new-api/src/v2/modules/members/services/member/findMemberByLogin.service.ts
+++ b/new-api/src/v2/modules/members/services/member/findMemberByLogin.service.ts
@@ -1,6 +1,7 @@
 import IRepositoryMember from '@modules/members/repositories/IRepositoryMember';
 import { EntityMember } from '@modules/members/typeorm/entities/member.entity';
 import { NotFoundException } from '@nestjs/common';
+import { ERRORS_NOT_FOUND } from '@utils/Errors/NotFound';
 
 interface IRequest {
   repository: IRepositoryMember;
@@ -14,7 +15,9 @@ const findByLogin = async ({
   const member = await repository.findByLogin(login);
 
   if (!member) {
-    throw new NotFoundException([`Not found member with loggin "${login}"`]);
+    throw new NotFoundException([
+      `${ERRORS_NOT_FOUND.NOT_FOUND_LOGIN} "${login}"`,
+    ]);
   }
 
   return member;

--- a/new-api/src/v2/modules/members/services/member/updateAvatarMember.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/updateAvatarMember.service.spec.ts
@@ -2,12 +2,7 @@ import MembersMock from '@modules/members/mocks/member.mock';
 import { FakeRepositoryMember } from '@modules/members/repositories/fakes/Member.fakeRepository';
 import { FakeRepositoryPatent } from '@modules/members/repositories/fakes/Patent.fakeRepository';
 import { EntityMember } from '@modules/members/typeorm/entities/member.entity';
-import {
-  BadRequestException,
-  ForbiddenException,
-  NotFoundException,
-  UnauthorizedException,
-} from '@nestjs/common';
+import { UnauthorizedException } from '@nestjs/common';
 import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import TARGET_FOLDER from '@providers/StorageProvider/enums/targetFolder.enum';
@@ -25,7 +20,7 @@ let fakeRepositoryMember: FakeRepositoryMember;
 const FakeStorageProviderMock = FakeStorageProvider as jest.Mock<FakeStorageProvider>;
 
 let fakeHashProvider: IHashProvider;
-let fakeStorageProviderMock: jest.Mocked<IStorageProvider>;
+let fakeStorageProvider: jest.Mocked<IStorageProvider>;
 
 let serviceMember: ServiceMember;
 
@@ -35,13 +30,13 @@ describe("Update Member's avatar  - SERVICES", () => {
     fakeRepositoryMember = new FakeRepositoryMember();
 
     fakeHashProvider = new FakeHashProvider();
-    fakeStorageProviderMock = new FakeStorageProviderMock() as jest.Mocked<FakeStorageProvider>;
+    fakeStorageProvider = new FakeStorageProviderMock() as jest.Mocked<FakeStorageProvider>;
 
     serviceMember = new ServiceMember(
       fakeRepositoryMember,
       fakeRepositoryPatent,
       fakeHashProvider,
-      fakeStorageProviderMock,
+      fakeStorageProvider,
     );
   });
 
@@ -64,12 +59,12 @@ describe("Update Member's avatar  - SERVICES", () => {
       expect(memberUpdated.id).toBe(memberLoggedIn.id);
       expect(memberUpdated.avatar).toBe(fileName);
 
-      expect(fakeStorageProviderMock.saveFile).toHaveBeenCalledTimes(1);
-      expect(fakeStorageProviderMock.saveFile).toHaveBeenNthCalledWith(1, {
+      expect(fakeStorageProvider.saveFile).toHaveBeenCalledTimes(1);
+      expect(fakeStorageProvider.saveFile).toHaveBeenNthCalledWith(1, {
         fileName,
         targetFolder: TARGET_FOLDER.MEMBERS,
       });
-      expect(fakeStorageProviderMock.deleteFile).toHaveBeenCalledTimes(0);
+      expect(fakeStorageProvider.deleteFile).toHaveBeenCalledTimes(0);
     });
 
     it("Should update the member's avatar when member logged in exists and he already have avatar", async () => {
@@ -98,13 +93,13 @@ describe("Update Member's avatar  - SERVICES", () => {
       expect(memberUpdated.id).toBe(memberLoggedIn.id);
       expect(memberUpdated.avatar).toBe(fileName);
 
-      expect(fakeStorageProviderMock.saveFile).toHaveBeenCalledTimes(1);
-      expect(fakeStorageProviderMock.saveFile).toHaveBeenNthCalledWith(1, {
+      expect(fakeStorageProvider.saveFile).toHaveBeenCalledTimes(1);
+      expect(fakeStorageProvider.saveFile).toHaveBeenNthCalledWith(1, {
         fileName,
         targetFolder: TARGET_FOLDER.MEMBERS,
       });
-      expect(fakeStorageProviderMock.deleteFile).toHaveBeenCalledTimes(1);
-      expect(fakeStorageProviderMock.deleteFile).toHaveBeenNthCalledWith(1, {
+      expect(fakeStorageProvider.deleteFile).toHaveBeenCalledTimes(1);
+      expect(fakeStorageProvider.deleteFile).toHaveBeenNthCalledWith(1, {
         fileName: oldFileName,
         targetFolder: TARGET_FOLDER.MEMBERS,
       });
@@ -133,8 +128,8 @@ describe("Update Member's avatar  - SERVICES", () => {
         `It should be logged in with a valid member`,
       ]);
 
-      expect(fakeStorageProviderMock.deleteFile).toHaveBeenCalledTimes(0);
-      expect(fakeStorageProviderMock.saveFile).toHaveBeenCalledTimes(0);
+      expect(fakeStorageProvider.deleteFile).toHaveBeenCalledTimes(0);
+      expect(fakeStorageProvider.saveFile).toHaveBeenCalledTimes(0);
     });
   });
 });

--- a/new-api/src/v2/modules/members/services/member/updateAvatarMember.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/updateAvatarMember.service.spec.ts
@@ -8,6 +8,7 @@ import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import TARGET_FOLDER from '@providers/StorageProvider/enums/targetFolder.enum';
 import FakeStorageProvider from '@providers/StorageProvider/implementations/fakes/FakeStorage.provider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
+import { ERRORS_UNAUTHORIZED } from '@utils/Errors/Unauthorized';
 import { ServiceMember } from '../member.service';
 
 jest.mock(
@@ -125,7 +126,7 @@ describe("Update Member's avatar  - SERVICES", () => {
       expect(memberNoUpdated).toBe(undefined);
       expect(error).toBeInstanceOf(UnauthorizedException);
       expect(error.response.message).toStrictEqual([
-        `It should be logged in with a valid member`,
+        ERRORS_UNAUTHORIZED.YOU_NEED_TO_BE_LOGGED_IN,
       ]);
 
       expect(fakeStorageProvider.deleteFile).toHaveBeenCalledTimes(0);

--- a/new-api/src/v2/modules/members/services/member/updateAvatarMember.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/updateAvatarMember.service.spec.ts
@@ -1,0 +1,140 @@
+import MembersMock from '@modules/members/mocks/member.mock';
+import { FakeRepositoryMember } from '@modules/members/repositories/fakes/Member.fakeRepository';
+import { FakeRepositoryPatent } from '@modules/members/repositories/fakes/Patent.fakeRepository';
+import { EntityMember } from '@modules/members/typeorm/entities/member.entity';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
+import IHashProvider from '@providers/HashProvider/models/IHashProvider';
+import TARGET_FOLDER from '@providers/StorageProvider/enums/targetFolder.enum';
+import FakeStorageProvider from '@providers/StorageProvider/implementations/fakes/FakeStorage.provider';
+import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
+import { ServiceMember } from '../member.service';
+
+jest.mock(
+  '@providers/StorageProvider/implementations/fakes/FakeStorage.provider',
+);
+
+let fakeRepositoryPatent: FakeRepositoryPatent;
+let fakeRepositoryMember: FakeRepositoryMember;
+
+const FakeStorageProviderMock = FakeStorageProvider as jest.Mock<FakeStorageProvider>;
+
+let fakeHashProvider: IHashProvider;
+let fakeStorageProviderMock: jest.Mocked<IStorageProvider>;
+
+let serviceMember: ServiceMember;
+
+describe("Update Member's avatar  - SERVICES", () => {
+  beforeEach(() => {
+    fakeRepositoryPatent = new FakeRepositoryPatent();
+    fakeRepositoryMember = new FakeRepositoryMember();
+
+    fakeHashProvider = new FakeHashProvider();
+    fakeStorageProviderMock = new FakeStorageProviderMock() as jest.Mocked<FakeStorageProvider>;
+
+    serviceMember = new ServiceMember(
+      fakeRepositoryMember,
+      fakeRepositoryPatent,
+      fakeHashProvider,
+      fakeStorageProviderMock,
+    );
+  });
+
+  describe('successful cases', () => {
+    it("Should add the member's avatar when member logged in exists and he don't have avatar", async () => {
+      const memberLoggedIn = await MembersMock.giveAMeAValidMember({
+        patentName: 'ADMINISTRATOR',
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const fileName = 'avatar_mock.jpg';
+
+      const memberUpdated = await serviceMember.updateAvatarMember({
+        fileName,
+        idMember: memberLoggedIn.id,
+      });
+
+      expect(memberUpdated).toBeInstanceOf(EntityMember);
+      expect(memberUpdated.id).toBe(memberLoggedIn.id);
+      expect(memberUpdated.avatar).toBe(fileName);
+
+      expect(fakeStorageProviderMock.saveFile).toHaveBeenCalledTimes(1);
+      expect(fakeStorageProviderMock.saveFile).toHaveBeenNthCalledWith(1, {
+        fileName,
+        targetFolder: TARGET_FOLDER.MEMBERS,
+      });
+      expect(fakeStorageProviderMock.deleteFile).toHaveBeenCalledTimes(0);
+    });
+
+    it("Should update the member's avatar when member logged in exists and he already have avatar", async () => {
+      const memberLoggedIn = await MembersMock.giveAMeAValidMember({
+        patentName: 'ADMINISTRATOR',
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const oldFileName = 'old_avatar_mock.jpg';
+
+      Object.assign(memberLoggedIn, {
+        avatar: oldFileName,
+      });
+
+      await fakeRepositoryMember.updateSave(memberLoggedIn);
+
+      const fileName = 'avatar_mock.jpg';
+
+      const memberUpdated = await serviceMember.updateAvatarMember({
+        fileName,
+        idMember: memberLoggedIn.id,
+      });
+
+      expect(memberUpdated).toBeInstanceOf(EntityMember);
+      expect(memberUpdated.id).toBe(memberLoggedIn.id);
+      expect(memberUpdated.avatar).toBe(fileName);
+
+      expect(fakeStorageProviderMock.saveFile).toHaveBeenCalledTimes(1);
+      expect(fakeStorageProviderMock.saveFile).toHaveBeenNthCalledWith(1, {
+        fileName,
+        targetFolder: TARGET_FOLDER.MEMBERS,
+      });
+      expect(fakeStorageProviderMock.deleteFile).toHaveBeenCalledTimes(1);
+      expect(fakeStorageProviderMock.deleteFile).toHaveBeenNthCalledWith(1, {
+        fileName: oldFileName,
+        targetFolder: TARGET_FOLDER.MEMBERS,
+      });
+    });
+  });
+
+  describe('failure cases', () => {
+    it('Should return UNAUTHORIZED when not the member logged in exists', async () => {
+      const fileName = 'avatar_mock.jpg';
+
+      let error;
+      let memberNoUpdated = undefined;
+
+      try {
+        memberNoUpdated = await serviceMember.updateAvatarMember({
+          fileName,
+          idMember: "id member doesn't exists",
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(memberNoUpdated).toBe(undefined);
+      expect(error).toBeInstanceOf(UnauthorizedException);
+      expect(error.response.message).toStrictEqual([
+        `It should be logged in with a valid member`,
+      ]);
+
+      expect(fakeStorageProviderMock.deleteFile).toHaveBeenCalledTimes(0);
+      expect(fakeStorageProviderMock.saveFile).toHaveBeenCalledTimes(0);
+    });
+  });
+});

--- a/new-api/src/v2/modules/members/services/member/updateAvatarMember.service.ts
+++ b/new-api/src/v2/modules/members/services/member/updateAvatarMember.service.ts
@@ -1,6 +1,5 @@
 import IRepositoryMember from '@modules/members/repositories/IRepositoryMember';
 import { EntityMember } from '@modules/members/typeorm/entities/member.entity';
-import { UnauthorizedException } from '@nestjs/common';
 import TARGET_FOLDER from '@providers/StorageProvider/enums/targetFolder.enum';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 

--- a/new-api/src/v2/modules/members/services/member/updateAvatarMember.service.ts
+++ b/new-api/src/v2/modules/members/services/member/updateAvatarMember.service.ts
@@ -6,41 +6,37 @@ import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider
 
 interface IRequest {
   repository: IRepositoryMember;
-  id: string;
+  loggedMember: EntityMember;
   storageProvider: IStorageProvider;
   fileName: string;
 }
 
 const updateAvatar = async ({
   repository,
-  id,
+  loggedMember,
   storageProvider,
   fileName,
 }: IRequest): Promise<EntityMember> => {
-  const member = await repository.findById(id);
   const targetFolder = TARGET_FOLDER.MEMBERS;
 
-  if (!member) {
-    throw new UnauthorizedException();
-  }
-
-  if (member.avatar) {
+  if (loggedMember.avatar) {
     await storageProvider.deleteFile({
-      fileName: member.avatar,
+      fileName: loggedMember.avatar,
       targetFolder,
     });
   } else {
-    member.avatar = fileName;
+    loggedMember.avatar = fileName;
     await repository.updateSave({
-      ...member,
+      ...loggedMember,
       avatar: fileName,
     });
   }
 
-  const memberWithNewAvatar = await repository.updateSave({
-    ...member,
+  Object.assign(loggedMember, {
     avatar: fileName,
   });
+
+  const memberWithNewAvatar = await repository.updateSave(loggedMember);
 
   await storageProvider.saveFile({
     fileName,

--- a/new-api/src/v2/modules/members/services/member/updateMember.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/updateMember.service.spec.ts
@@ -12,6 +12,7 @@ import FakeHashProvider from '@providers/HashProvider/implementations/fakes/Fake
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import FakeStorageProvider from '@providers/StorageProvider/implementations/fakes/FakeStorage.provider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
+import { ERRORS_UNAUTHORIZED } from '@utils/Errors/Unauthorized';
 import { ServiceMember } from '../member.service';
 
 jest.mock('@providers/HashProvider/implementations/fakes/FakeHashProvider');
@@ -155,7 +156,7 @@ describe('Update Member  - SERVICES', () => {
       expect(memberNoUpdated).toBe(undefined);
       expect(error).toBeInstanceOf(UnauthorizedException);
       expect(error.response.message).toStrictEqual([
-        `It should be logged in with a valid member`,
+        ERRORS_UNAUTHORIZED.YOU_NEED_TO_BE_LOGGED_IN,
       ]);
 
       expect(fakeHashProviderMock.generateHash).toHaveBeenCalledTimes(0);

--- a/new-api/src/v2/modules/members/services/member/updateMember.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/updateMember.service.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '@nestjs/common';
 import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
+import FakeStorageProvider from '@providers/StorageProvider/implementations/fakes/FakeStorage.provider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 import { ServiceMember } from '../member.service';
 
@@ -21,8 +22,7 @@ let fakeRepositoryMember: FakeRepositoryMember;
 const FakeHashProviderMock = FakeHashProvider as jest.Mock<FakeHashProvider>;
 
 let fakeHashProviderMock: jest.Mocked<IHashProvider>;
-
-let iStorageProver: IStorageProvider;
+let fakeStorageProvider: IStorageProvider;
 
 let serviceMember: ServiceMember;
 
@@ -32,12 +32,13 @@ describe('Update Member  - SERVICES', () => {
     fakeRepositoryMember = new FakeRepositoryMember();
 
     fakeHashProviderMock = new FakeHashProviderMock() as jest.Mocked<FakeHashProvider>;
+    fakeStorageProvider = new FakeStorageProvider();
 
     serviceMember = new ServiceMember(
       fakeRepositoryMember,
       fakeRepositoryPatent,
       fakeHashProviderMock,
-      iStorageProver,
+      fakeStorageProvider,
     );
   });
 

--- a/new-api/src/v2/modules/members/services/member/updateMember.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/updateMember.service.spec.ts
@@ -1,0 +1,314 @@
+import { IUpdateMemberBasicDataDTO } from '@modules/members/dtos/IUpdateMember.dto';
+import MembersMock from '@modules/members/mocks/member.mock';
+import { FakeRepositoryMember } from '@modules/members/repositories/fakes/Member.fakeRepository';
+import { FakeRepositoryPatent } from '@modules/members/repositories/fakes/Patent.fakeRepository';
+import { EntityMember } from '@modules/members/typeorm/entities/member.entity';
+import {
+  BadRequestException,
+  ConflictException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
+import IHashProvider from '@providers/HashProvider/models/IHashProvider';
+import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
+import { ServiceMember } from '../member.service';
+
+jest.mock('@providers/HashProvider/implementations/fakes/FakeHashProvider');
+
+let fakeRepositoryPatent: FakeRepositoryPatent;
+let fakeRepositoryMember: FakeRepositoryMember;
+
+const FakeHashProviderMock = FakeHashProvider as jest.Mock<FakeHashProvider>;
+
+let fakeHashProviderMock: jest.Mocked<IHashProvider>;
+
+let iStorageProver: IStorageProvider;
+
+let serviceMember: ServiceMember;
+
+describe('Update Member  - SERVICES', () => {
+  beforeEach(() => {
+    fakeRepositoryPatent = new FakeRepositoryPatent();
+    fakeRepositoryMember = new FakeRepositoryMember();
+
+    fakeHashProviderMock = new FakeHashProviderMock() as jest.Mocked<FakeHashProvider>;
+
+    serviceMember = new ServiceMember(
+      fakeRepositoryMember,
+      fakeRepositoryPatent,
+      fakeHashProviderMock,
+      iStorageProver,
+    );
+  });
+
+  describe('successful cases', () => {
+    it('should update a member when basic datas is valid and the member logged in exists', async () => {
+      const memberLoggedIn = await MembersMock.giveAMeAValidMember({
+        patentName: 'ADMINISTRATOR',
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const newMemberData: IUpdateMemberBasicDataDTO = {
+        name: 'Name updated',
+        email: 'email.updated@mock.test',
+        login: 'login.updated',
+        linkedin: 'linkedin updated',
+        gitHub: 'gitHub updated',
+        lattes: 'lattes updated',
+        quoteName: 'quoteName updated',
+        description: 'description updated',
+      };
+
+      const memberUpdated = await serviceMember.updateMember({
+        newMemberData,
+        idMember: memberLoggedIn.id,
+      });
+
+      expect(memberUpdated).toBeInstanceOf(EntityMember);
+      expect(memberUpdated.id).toBe(memberLoggedIn.id);
+      expect(memberUpdated.name).toBe(newMemberData.name);
+      expect(memberUpdated.email).toBe(newMemberData.email);
+      expect(memberUpdated.login).toBe(newMemberData.login);
+      expect(memberUpdated.linkedin).toBe(newMemberData.linkedin);
+      expect(memberUpdated.gitHub).toBe(newMemberData.gitHub);
+      expect(memberUpdated.lattes).toBe(newMemberData.lattes);
+      expect(memberUpdated.quoteName).toBe(newMemberData.quoteName);
+      expect(memberUpdated.description).toBe(newMemberData.description);
+
+      expect(fakeHashProviderMock.generateHash).toHaveBeenCalledTimes(0);
+      expect(fakeHashProviderMock.compareHash).toHaveBeenCalledTimes(0);
+    });
+
+    it("should update a member's password when oldPassword, newPassword are informed and oldPassword is valid", async () => {
+      fakeHashProviderMock.compareHash.mockResolvedValueOnce(true);
+
+      const memberLoggedIn = await MembersMock.giveAMeAValidMember({
+        patentName: 'ADMINISTRATOR',
+        password: 'old password',
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const newMemberData: IUpdateMemberBasicDataDTO = {
+        name: memberLoggedIn.name,
+        email: memberLoggedIn.email,
+        login: memberLoggedIn.login,
+        linkedin: memberLoggedIn.linkedin,
+        gitHub: memberLoggedIn.gitHub,
+        lattes: memberLoggedIn.lattes,
+        quoteName: memberLoggedIn.quoteName,
+        description: memberLoggedIn.description,
+        oldPassword: 'old password',
+        newPassword: 'new password',
+      };
+
+      const memberUpdated = await serviceMember.updateMember({
+        newMemberData,
+        idMember: memberLoggedIn.id,
+      });
+
+      // console.log(memberUpdated.password, ' === ', memberLoggedIn.password);
+
+      expect(memberUpdated).toBeInstanceOf(EntityMember);
+      expect(memberUpdated.id).toBe(memberLoggedIn.id);
+      expect(memberUpdated.name).toBe(memberLoggedIn.name);
+      expect(memberUpdated.email).toBe(memberLoggedIn.email);
+      expect(memberUpdated.login).toBe(memberLoggedIn.login);
+      expect(memberUpdated.linkedin).toBe(memberLoggedIn.linkedin);
+      expect(memberUpdated.gitHub).toBe(memberLoggedIn.gitHub);
+      expect(memberUpdated.lattes).toBe(memberLoggedIn.lattes);
+      expect(memberUpdated.quoteName).toBe(memberLoggedIn.quoteName);
+      expect(memberUpdated.description).toBe(memberLoggedIn.description);
+
+      expect(fakeHashProviderMock.compareHash).toHaveBeenCalledTimes(1);
+      expect(fakeHashProviderMock.generateHash).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('failure cases', () => {
+    it('Should return UNAUTHORIZED when not the member logged in exists', async () => {
+      const newMemberData: IUpdateMemberBasicDataDTO = {
+        name: 'Name updated',
+        email: 'email.updated@mock.test',
+        login: 'login.updated',
+        linkedin: 'linkedin updated',
+        gitHub: 'gitHub updated',
+        lattes: 'lattes updated',
+        quoteName: 'quoteName updated',
+        description: 'description updated',
+      };
+
+      let error;
+      let memberNoUpdated = undefined;
+
+      try {
+        memberNoUpdated = await serviceMember.updateMember({
+          newMemberData,
+          idMember: "id member doesn't exists",
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(memberNoUpdated).toBe(undefined);
+      expect(error).toBeInstanceOf(UnauthorizedException);
+      expect(error.response.message).toStrictEqual([
+        `It should be logged in with a valid member`,
+      ]);
+
+      expect(fakeHashProviderMock.generateHash).toHaveBeenCalledTimes(0);
+      expect(fakeHashProviderMock.compareHash).toHaveBeenCalledTimes(0);
+    });
+
+    it('Should return CONFLICT when the unique datas already exists in another member', async () => {
+      const memberLoggedIn = await MembersMock.giveAMeAValidMember({
+        patentName: 'ADMINISTRATOR',
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const conflictDatas = {
+        email: 'conflic.mail@test.com',
+        login: 'conflict login',
+        linkedin: 'conflict linkedin',
+        lattes: 'conflict lattes',
+        gitHub: 'conflict gitHub',
+        quoteName: 'conflict quoteName',
+      };
+
+      const memberToConflict = await MembersMock.giveAMeAValidMember({
+        patentName: 'Any patent',
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      Object.assign(memberToConflict, conflictDatas);
+
+      await fakeRepositoryMember.updateSave(memberToConflict);
+
+      const newMemberData: IUpdateMemberBasicDataDTO = {
+        name: 'Name updated',
+        description: 'description updated',
+        ...conflictDatas,
+      };
+
+      let error;
+      let membersNoUpdated = undefined;
+      try {
+        membersNoUpdated = await serviceMember.updateMember({
+          idMember: memberLoggedIn.id,
+          newMemberData,
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      const memberThatShouldHaveBeenUpdated = await fakeRepositoryMember.findByLogin(
+        memberLoggedIn.login,
+      );
+
+      expect(membersNoUpdated).toBe(undefined);
+
+      expect(memberThatShouldHaveBeenUpdated.id).toBe(memberLoggedIn.id);
+      expect(memberThatShouldHaveBeenUpdated.name).toBe(memberLoggedIn.name);
+      expect(memberThatShouldHaveBeenUpdated.email).toBe(memberLoggedIn.email);
+      expect(memberThatShouldHaveBeenUpdated.login).toBe(memberLoggedIn.login);
+      expect(memberThatShouldHaveBeenUpdated.linkedin).toBe(
+        memberLoggedIn.linkedin,
+      );
+      expect(memberThatShouldHaveBeenUpdated.gitHub).toBe(
+        memberLoggedIn.gitHub,
+      );
+      expect(memberThatShouldHaveBeenUpdated.lattes).toBe(
+        memberLoggedIn.lattes,
+      );
+      expect(memberThatShouldHaveBeenUpdated.quoteName).toBe(
+        memberLoggedIn.quoteName,
+      );
+      expect(memberThatShouldHaveBeenUpdated.description).toBe(
+        memberLoggedIn.description,
+      );
+
+      expect(error).toBeInstanceOf(ConflictException);
+      expect(error.response.message).toStrictEqual([
+        `The email "${conflictDatas.email}" already exists`,
+        `The login "${conflictDatas.login}" already exists`,
+        `The linkedin "${conflictDatas.linkedin}" already exists`,
+        `The lattes "${conflictDatas.lattes}" already exists`,
+        `The gitHub "${conflictDatas.gitHub}" already exists`,
+        `The quoteName "${conflictDatas.quoteName}" already exists`,
+      ]);
+      expect(fakeHashProviderMock.compareHash).toHaveBeenCalledTimes(0);
+      expect(fakeHashProviderMock.generateHash).toHaveBeenCalledTimes(0);
+    });
+
+    it("Should return BAD_REQUEST when oldPassword isn't macthing member's current password", async () => {
+      fakeHashProviderMock.compareHash.mockResolvedValueOnce(false);
+
+      const memberLoggedIn = await MembersMock.giveAMeAValidMember({
+        patentName: 'ADMINISTRATOR',
+        password: 'old password',
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const newMemberData: IUpdateMemberBasicDataDTO = {
+        name: memberLoggedIn.name,
+        email: memberLoggedIn.email,
+        login: memberLoggedIn.login,
+        linkedin: memberLoggedIn.linkedin,
+        gitHub: memberLoggedIn.gitHub,
+        lattes: memberLoggedIn.lattes,
+        quoteName: memberLoggedIn.quoteName,
+        description: memberLoggedIn.description,
+        oldPassword: 'Invalid old password',
+        newPassword: 'new password',
+      };
+
+      let error;
+      let membersNoUpdated = undefined;
+
+      try {
+        membersNoUpdated = await serviceMember.updateMember({
+          idMember: memberLoggedIn.id,
+          newMemberData,
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      const memberThatShouldHaveBeenUpdated = await fakeRepositoryMember.findByLogin(
+        memberLoggedIn.login,
+      );
+
+      expect(membersNoUpdated).toBe(undefined);
+
+      expect(memberThatShouldHaveBeenUpdated.id).toBe(memberLoggedIn.id);
+      expect(memberThatShouldHaveBeenUpdated.name).toBe(memberLoggedIn.name);
+      expect(memberThatShouldHaveBeenUpdated.email).toBe(memberLoggedIn.email);
+      expect(memberThatShouldHaveBeenUpdated.login).toBe(memberLoggedIn.login);
+      expect(memberThatShouldHaveBeenUpdated.linkedin).toBe(
+        memberLoggedIn.linkedin,
+      );
+      expect(memberThatShouldHaveBeenUpdated.gitHub).toBe(
+        memberLoggedIn.gitHub,
+      );
+      expect(memberThatShouldHaveBeenUpdated.lattes).toBe(
+        memberLoggedIn.lattes,
+      );
+      expect(memberThatShouldHaveBeenUpdated.quoteName).toBe(
+        memberLoggedIn.quoteName,
+      );
+      expect(memberThatShouldHaveBeenUpdated.description).toBe(
+        memberLoggedIn.description,
+      );
+
+      expect(error).toBeInstanceOf(BadRequestException);
+      expect(error.response.message).toStrictEqual(['Invalid Old password']);
+
+      expect(fakeHashProviderMock.compareHash).toHaveBeenCalledTimes(1);
+      expect(fakeHashProviderMock.generateHash).toHaveBeenCalledTimes(0);
+    });
+  });
+});

--- a/new-api/src/v2/modules/members/services/member/updateMember.service.ts
+++ b/new-api/src/v2/modules/members/services/member/updateMember.service.ts
@@ -1,16 +1,14 @@
+import IFindConflictDTO from '@modules/members/dtos/IFindConflict.dto';
 import { IUpdateMemberBasicDataDTO } from '@modules/members/dtos/IUpdateMember.dto';
 import IRepositoryMember from '@modules/members/repositories/IRepositoryMember';
 import { EntityMember } from '@modules/members/typeorm/entities/member.entity';
-import { BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { BadRequestException, ConflictException } from '@nestjs/common';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
-
-interface IUpdateMemberData extends IUpdateMemberBasicDataDTO {
-  id: string;
-}
 
 interface IRequest {
   repository: IRepositoryMember;
-  newMemberData: IUpdateMemberData;
+  loggedMember: EntityMember;
+  newMemberData: IUpdateMemberBasicDataDTO;
   hashProvider: IHashProvider;
 }
 
@@ -18,30 +16,65 @@ const update = async ({
   repository,
   newMemberData,
   hashProvider,
+  loggedMember,
 }: IRequest): Promise<EntityMember> => {
-  const member = await repository.findById(newMemberData.id);
-
-  if (!member) {
-    throw new UnauthorizedException();
-  }
-
   if (
     newMemberData.oldPassword &&
     !(await hashProvider.compareHash(
       newMemberData.oldPassword,
-      member.password,
+      loggedMember.password,
     ))
   ) {
-    throw new BadRequestException('Invalid Old password');
+    throw new BadRequestException(['Invalid Old password']);
   }
 
-  return repository.updateSave({
-    ...member,
+  await checkConflict(
+    {
+      email: newMemberData.email,
+      login: newMemberData.login,
+      linkedin: newMemberData.linkedin,
+      lattes: newMemberData.lattes,
+      gitHub: newMemberData.gitHub,
+      quoteName: newMemberData.quoteName,
+    },
+    loggedMember.id,
+    repository,
+  );
+
+  Object.assign(loggedMember, {
     ...newMemberData,
     password:
       newMemberData.oldPassword &&
       (await hashProvider.generateHash(newMemberData.newPassword)),
   });
+
+  return repository.updateSave(loggedMember);
+};
+
+const checkConflict = async (
+  uniqueDatas: IFindConflictDTO,
+  idMemberLogged: string,
+  repository: IRepositoryMember,
+) => {
+  const conflicts: string[] = [];
+
+  await Promise.all(
+    Object.keys(uniqueDatas).map(async (attribute) => {
+      const attributeExists = await repository.findConflict({
+        [attribute]: uniqueDatas[attribute],
+      });
+
+      if (attributeExists && attributeExists.id !== idMemberLogged) {
+        conflicts.push(
+          `The ${attribute} "${uniqueDatas[attribute]}" already exists`,
+        );
+      }
+    }),
+  );
+
+  if (conflicts.length > 0) {
+    throw new ConflictException(conflicts);
+  }
 };
 
 export default update;

--- a/new-api/src/v2/modules/members/services/member/updatePatentMember.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/updatePatentMember.service.spec.ts
@@ -12,6 +12,7 @@ import FakeHashProvider from '@providers/HashProvider/implementations/fakes/Fake
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import FakeStorageProvider from '@providers/StorageProvider/implementations/fakes/FakeStorage.provider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
+import { ERRORS_NOT_FOUND } from '@utils/Errors/NotFound';
 import { ERRORS_UNAUTHORIZED } from '@utils/Errors/Unauthorized';
 import { ServiceMember } from '../member.service';
 
@@ -237,7 +238,7 @@ describe("Update Member's patent  - SERVICES", () => {
       expect(memberUpdated).toBe(undefined);
       expect(error).toBeInstanceOf(NotFoundException);
       expect(error.response.message).toStrictEqual([
-        `Not found member with login "${updatedMemberLogin}"`,
+        `${ERRORS_NOT_FOUND.NOT_FOUND_LOGIN} "${updatedMemberLogin}"`,
       ]);
     });
 

--- a/new-api/src/v2/modules/members/services/member/updatePatentMember.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/updatePatentMember.service.spec.ts
@@ -12,6 +12,7 @@ import FakeHashProvider from '@providers/HashProvider/implementations/fakes/Fake
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import FakeStorageProvider from '@providers/StorageProvider/implementations/fakes/FakeStorage.provider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
+import { ERRORS_UNAUTHORIZED } from '@utils/Errors/Unauthorized';
 import { ServiceMember } from '../member.service';
 
 let fakeRepositoryPatent: FakeRepositoryPatent;
@@ -161,7 +162,7 @@ describe("Update Member's patent  - SERVICES", () => {
       expect(memberToUpdate).toMatchObject(memberThatShouldHaveBeenUpdated);
       expect(error).toBeInstanceOf(UnauthorizedException);
       expect(error.response.message).toStrictEqual([
-        `It should be logged in with a valid member`,
+        ERRORS_UNAUTHORIZED.YOU_NEED_TO_BE_LOGGED_IN,
       ]);
     });
 

--- a/new-api/src/v2/modules/members/services/member/updatePatentMember.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/updatePatentMember.service.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '@nestjs/common';
 import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
+import FakeStorageProvider from '@providers/StorageProvider/implementations/fakes/FakeStorage.provider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 import { ServiceMember } from '../member.service';
 
@@ -17,7 +18,7 @@ let fakeRepositoryPatent: FakeRepositoryPatent;
 let fakeRepositoryMember: FakeRepositoryMember;
 
 let fakeHashProvider: IHashProvider;
-let iStorageProver: IStorageProvider;
+let fakeStorageProvider: IStorageProvider;
 
 let serviceMember: ServiceMember;
 
@@ -25,12 +26,15 @@ describe("Update Member's patent  - SERVICES", () => {
   beforeEach(() => {
     fakeRepositoryPatent = new FakeRepositoryPatent();
     fakeRepositoryMember = new FakeRepositoryMember();
+
     fakeHashProvider = new FakeHashProvider();
+    fakeStorageProvider = new FakeStorageProvider();
+
     serviceMember = new ServiceMember(
       fakeRepositoryMember,
       fakeRepositoryPatent,
       fakeHashProvider,
-      iStorageProver,
+      fakeStorageProvider,
     );
   });
 

--- a/new-api/src/v2/modules/members/services/member/updatePatentMember.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/updatePatentMember.service.spec.ts
@@ -1,0 +1,279 @@
+import MembersMock from '@modules/members/mocks/member.mock';
+import { FakeRepositoryMember } from '@modules/members/repositories/fakes/Member.fakeRepository';
+import { FakeRepositoryPatent } from '@modules/members/repositories/fakes/Patent.fakeRepository';
+import { EntityMember } from '@modules/members/typeorm/entities/member.entity';
+import {
+  BadRequestException,
+  ForbiddenException,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
+import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
+import IHashProvider from '@providers/HashProvider/models/IHashProvider';
+import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
+import { ServiceMember } from '../member.service';
+
+let fakeRepositoryPatent: FakeRepositoryPatent;
+let fakeRepositoryMember: FakeRepositoryMember;
+
+let fakeHashProvider: IHashProvider;
+let iStorageProver: IStorageProvider;
+
+let serviceMember: ServiceMember;
+
+describe("Update Member's patent  - SERVICES", () => {
+  beforeEach(() => {
+    fakeRepositoryPatent = new FakeRepositoryPatent();
+    fakeRepositoryMember = new FakeRepositoryMember();
+    fakeHashProvider = new FakeHashProvider();
+    serviceMember = new ServiceMember(
+      fakeRepositoryMember,
+      fakeRepositoryPatent,
+      fakeHashProvider,
+      iStorageProver,
+    );
+  });
+
+  describe('successful cases', () => {
+    it("Should update the member's patent when member id exist, patent id exists and member logged in is ADMINISTRATOR", async () => {
+      const memberLoggedIn = await MembersMock.giveAMeAValidMember({
+        patentName: 'ADMINISTRATOR',
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const memberToUpdate = await MembersMock.giveAMeAValidMember({
+        patentName: 'ADMINISTRATOR',
+        login: "Member's login to update",
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const newMemberPatent = await fakeRepositoryPatent.createSave({
+        name: "Member's new patent",
+      });
+
+      const memberUpdated = await serviceMember.updatePatentMember({
+        idMemberLogged: memberLoggedIn.id,
+        updatedMemberLogin: memberToUpdate.login,
+        newPatentId: newMemberPatent.id,
+      });
+
+      expect(memberUpdated).toBeInstanceOf(EntityMember);
+      expect(memberUpdated.id).toBe(memberToUpdate.id);
+      expect(memberUpdated.patent).toMatchObject(newMemberPatent);
+    });
+
+    it("Should update the member's patent when member id exist, patent id exists and member logged in is ADVISOR", async () => {
+      const memberLoggedIn = await MembersMock.giveAMeAValidMember({
+        patentName: 'ADVISOR',
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const memberToUpdate = await MembersMock.giveAMeAValidMember({
+        patentName: 'ADMINISTRATOR',
+        login: "Member's login to update",
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const newMemberPatent = await fakeRepositoryPatent.createSave({
+        name: "Member's new patent",
+      });
+
+      const memberUpdated = await serviceMember.updatePatentMember({
+        idMemberLogged: memberLoggedIn.id,
+        updatedMemberLogin: memberToUpdate.login,
+        newPatentId: newMemberPatent.id,
+      });
+
+      expect(memberUpdated).toBeInstanceOf(EntityMember);
+      expect(memberUpdated.id).toBe(memberToUpdate.id);
+      expect(memberUpdated.patent).toMatchObject(newMemberPatent);
+    });
+
+    it("Should update the member's patent when member id exist, patent id exists and member logged in is COORDINATOR", async () => {
+      const memberLoggedIn = await MembersMock.giveAMeAValidMember({
+        patentName: 'COORDINATOR',
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const memberToUpdate = await MembersMock.giveAMeAValidMember({
+        patentName: 'ADMINISTRATOR',
+        login: "Member's login to update",
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const newMemberPatent = await fakeRepositoryPatent.createSave({
+        name: "Member's new patent",
+      });
+
+      const memberUpdated = await serviceMember.updatePatentMember({
+        idMemberLogged: memberLoggedIn.id,
+        updatedMemberLogin: memberToUpdate.login,
+        newPatentId: newMemberPatent.id,
+      });
+
+      expect(memberUpdated).toBeInstanceOf(EntityMember);
+      expect(memberUpdated.id).toBe(memberToUpdate.id);
+      expect(memberUpdated.patent).toMatchObject(newMemberPatent);
+    });
+  });
+
+  describe('failure cases', () => {
+    it('Should return UNAUTHORIZED when not the member logged in exists', async () => {
+      const memberToUpdate = await MembersMock.giveAMeAValidMember({
+        patentName: 'ADMINISTRATOR',
+        login: "Member's login to update",
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const newMemberPatent = await fakeRepositoryPatent.createSave({
+        name: "Member's new patent",
+      });
+
+      let error;
+      let memberUpdated = undefined;
+
+      try {
+        memberUpdated = await serviceMember.updatePatentMember({
+          idMemberLogged: "id member doesn't exists",
+          updatedMemberLogin: memberToUpdate.login,
+          newPatentId: newMemberPatent.id,
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      const memberThatShouldHaveBeenUpdated = await fakeRepositoryMember.findByLogin(
+        memberToUpdate.login,
+      );
+
+      expect(memberUpdated).toBe(undefined);
+      expect(memberToUpdate).toMatchObject(memberThatShouldHaveBeenUpdated);
+      expect(error).toBeInstanceOf(UnauthorizedException);
+      expect(error.response.message).toStrictEqual([
+        `It should be logged in with a valid member`,
+      ]);
+    });
+
+    it('Should return FORBIDDEN when the member that is logged in is different from: ADMINISTRATOR; ADVISOR; COORDINATOR', async () => {
+      const memberLoggedIn = await MembersMock.giveAMeAValidMember({
+        patentName: 'Patent without permission',
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const memberToUpdate = await MembersMock.giveAMeAValidMember({
+        patentName: 'ADMINISTRATOR',
+        login: "Member's login to update",
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const newMemberPatent = await fakeRepositoryPatent.createSave({
+        name: "Member's new patent",
+      });
+
+      let error;
+      let memberUpdated = undefined;
+
+      try {
+        memberUpdated = await serviceMember.updatePatentMember({
+          idMemberLogged: memberLoggedIn.id,
+          updatedMemberLogin: memberToUpdate.login,
+          newPatentId: newMemberPatent.id,
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      const memberThatShouldHaveBeenUpdated = await fakeRepositoryMember.findByLogin(
+        memberToUpdate.login,
+      );
+
+      expect(memberUpdated).toBe(undefined);
+      expect(memberToUpdate).toMatchObject(memberThatShouldHaveBeenUpdated);
+      expect(error).toBeInstanceOf(ForbiddenException);
+      expect(error.response.message).toStrictEqual([
+        `Your patent don't have permission for updating patent of the member`,
+      ]);
+    });
+
+    it("Should return NOT_FOUNT when the member that will be update doesn't exists", async () => {
+      const memberLoggedIn = await MembersMock.giveAMeAValidMember({
+        patentName: 'ADMINISTRATOR',
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const newMemberPatent = await fakeRepositoryPatent.createSave({
+        name: "Member's new patent",
+      });
+
+      let error;
+      let memberUpdated = undefined;
+      const updatedMemberLogin = "Member's login to update doesn't exists";
+
+      try {
+        memberUpdated = await serviceMember.updatePatentMember({
+          idMemberLogged: memberLoggedIn.id,
+          updatedMemberLogin,
+          newPatentId: newMemberPatent.id,
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      expect(memberUpdated).toBe(undefined);
+      expect(error).toBeInstanceOf(NotFoundException);
+      expect(error.response.message).toStrictEqual([
+        `Not found member with login "${updatedMemberLogin}"`,
+      ]);
+    });
+
+    it("Should return BAD_REQUEST when the patent's id doesn't exists", async () => {
+      const memberLoggedIn = await MembersMock.giveAMeAValidMember({
+        patentName: 'ADMINISTRATOR',
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      const memberToUpdate = await MembersMock.giveAMeAValidMember({
+        patentName: 'ADMINISTRATOR',
+        login: "Member's login to update",
+        fakeRepositoryMember,
+        fakeRepositoryPatent,
+      });
+
+      let error;
+      let memberUpdated = undefined;
+      const newPatentId = "id patent doesn't exists";
+
+      try {
+        memberUpdated = await serviceMember.updatePatentMember({
+          idMemberLogged: memberLoggedIn.id,
+          updatedMemberLogin: memberToUpdate.login,
+          newPatentId,
+        });
+      } catch (err) {
+        error = err;
+      }
+
+      const memberThatShouldHaveBeenUpdated = await fakeRepositoryMember.findByLogin(
+        memberToUpdate.login,
+      );
+
+      expect(memberUpdated).toBe(undefined);
+      expect(memberToUpdate).toMatchObject(memberThatShouldHaveBeenUpdated);
+      expect(error).toBeInstanceOf(BadRequestException);
+      expect(error.response.message).toStrictEqual([
+        `Not found patent with id "${newPatentId}"`,
+      ]);
+    });
+  });
+});

--- a/new-api/src/v2/modules/members/services/member/updatePatentMember.service.spec.ts
+++ b/new-api/src/v2/modules/members/services/member/updatePatentMember.service.spec.ts
@@ -12,6 +12,7 @@ import FakeHashProvider from '@providers/HashProvider/implementations/fakes/Fake
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import FakeStorageProvider from '@providers/StorageProvider/implementations/fakes/FakeStorage.provider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
+import { ERRORS_FORBIDDEN } from '@utils/Errors/Forbidden';
 import { ERRORS_NOT_FOUND } from '@utils/Errors/NotFound';
 import { ERRORS_UNAUTHORIZED } from '@utils/Errors/Unauthorized';
 import { ServiceMember } from '../member.service';
@@ -206,7 +207,7 @@ describe("Update Member's patent  - SERVICES", () => {
       expect(memberToUpdate).toMatchObject(memberThatShouldHaveBeenUpdated);
       expect(error).toBeInstanceOf(ForbiddenException);
       expect(error.response.message).toStrictEqual([
-        `Your patent don't have permission for updating patent of the member`,
+        ERRORS_FORBIDDEN.PATENT_DONT_HAVE_PERMISSION_FOR_UPDATE_MEMBER,
       ]);
     });
 

--- a/new-api/src/v2/modules/members/services/member/updatePatentMember.service.ts
+++ b/new-api/src/v2/modules/members/services/member/updatePatentMember.service.ts
@@ -19,11 +19,13 @@ const updatePatent = async ({
 }: IRequest): Promise<EntityMember> => {
   if (!hasCreatePermission(loggedMember.patent.id)) {
     throw new ForbiddenException([
-      "don'tYour patent don't have permission for updating patent of the member",
+      "Your patent don't have permission for updating patent of the member",
     ]);
   }
 
-  return repository.updateSave({ ...updatedMember, patent: newPatent });
+  updatedMember.patent = newPatent;
+
+  return repository.updateSave(updatedMember);
 };
 
 export default updatePatent;

--- a/new-api/src/v2/modules/members/services/member/updatePatentMember.service.ts
+++ b/new-api/src/v2/modules/members/services/member/updatePatentMember.service.ts
@@ -3,6 +3,7 @@ import IRepositoryMember from '@modules/members/repositories/IRepositoryMember';
 import { EntityMember } from '@modules/members/typeorm/entities/member.entity';
 import { EntityPatent } from '@modules/members/typeorm/entities/patent.entity';
 import { ForbiddenException } from '@nestjs/common';
+import { ERRORS_FORBIDDEN } from '@utils/Errors/Forbidden';
 
 interface IRequest {
   repository: IRepositoryMember;
@@ -19,7 +20,7 @@ const updatePatent = async ({
 }: IRequest): Promise<EntityMember> => {
   if (!hasCreatePermission(loggedMember.patent.id)) {
     throw new ForbiddenException([
-      "Your patent don't have permission for updating patent of the member",
+      ERRORS_FORBIDDEN.PATENT_DONT_HAVE_PERMISSION_FOR_UPDATE_MEMBER,
     ]);
   }
 

--- a/new-api/src/v2/modules/members/services/member/updatePatentMember.service.ts
+++ b/new-api/src/v2/modules/members/services/member/updatePatentMember.service.ts
@@ -19,7 +19,7 @@ const updatePatent = async ({
 }: IRequest): Promise<EntityMember> => {
   if (!hasCreatePermission(loggedMember.patent.id)) {
     throw new ForbiddenException([
-      'Your patent not have permission for updating patent of the member',
+      "don'tYour patent don't have permission for updating patent of the member",
     ]);
   }
 

--- a/new-api/src/v2/modules/members/services/patent.service.ts
+++ b/new-api/src/v2/modules/members/services/patent.service.ts
@@ -3,6 +3,7 @@ import IOrderByDTO, {
 } from '@modules/shared/dtos/IOrderBy.dto';
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { ERRORS_UNAUTHORIZED } from '@utils/Errors/Unauthorized';
 import { ICreatePatentDTO } from '../dtos/Patent/ICreatePatent.dto';
 import IRepositoryMember from '../repositories/IRepositoryMember';
 import IRepositoryPatent from '../repositories/IRepositoryPatent';
@@ -28,7 +29,9 @@ export class ServicePatent {
     const member = await this.memberRepository.findById(idMember);
 
     if (!member) {
-      throw new UnauthorizedException(['I need to be logged in']);
+      throw new UnauthorizedException([
+        ERRORS_UNAUTHORIZED.YOU_NEED_TO_BE_LOGGED_IN,
+      ]);
     }
 
     return services.create({

--- a/new-api/src/v2/modules/members/services/patent/createPatent.service.ts
+++ b/new-api/src/v2/modules/members/services/patent/createPatent.service.ts
@@ -3,6 +3,7 @@ import { hasCreatePermission } from '@modules/members/enums/CREATION_PERMISSION_
 import IRepositoryPatent from '@modules/members/repositories/IRepositoryPatent';
 import { EntityPatent } from '@modules/members/typeorm/entities/patent.entity';
 import { ConflictException, ForbiddenException } from '@nestjs/common';
+import { ERRORS_FORBIDDEN } from '@utils/Errors/Forbidden';
 
 interface IRequest extends ICreatePatentServiceDTO {
   repository: IRepositoryPatent;
@@ -15,7 +16,7 @@ const create = async ({
 }: IRequest): Promise<EntityPatent> => {
   if (!hasCreatePermission(member.patent.id)) {
     throw new ForbiddenException([
-      "Your patent don't have permission for creating a new patent",
+      ERRORS_FORBIDDEN.PATENT_DONT_HAVE_PERMISSION_FOR_CREATE_PATENT,
     ]);
   }
 

--- a/new-api/src/v2/modules/members/services/patent/createPatent.service.ts
+++ b/new-api/src/v2/modules/members/services/patent/createPatent.service.ts
@@ -15,7 +15,7 @@ const create = async ({
 }: IRequest): Promise<EntityPatent> => {
   if (!hasCreatePermission(member.patent.id)) {
     throw new ForbiddenException([
-      'Your patent not have permission for creating a new patent',
+      "Your patent don't have permission for creating a new patent",
     ]);
   }
 

--- a/new-api/src/v2/modules/members/services/patent/findOnePatentByName.service.ts
+++ b/new-api/src/v2/modules/members/services/patent/findOnePatentByName.service.ts
@@ -1,6 +1,7 @@
 import IRepositoryPatent from '@modules/members/repositories/IRepositoryPatent';
 import { EntityPatent } from '@modules/members/typeorm/entities/patent.entity';
 import { NotFoundException } from '@nestjs/common';
+import { ERRORS_NOT_FOUND } from '@utils/Errors/NotFound';
 
 interface IRequest {
   repository: IRepositoryPatent;
@@ -14,7 +15,9 @@ const findOnePatentByName = async ({
   const patent = await repository.findByName(name);
 
   if (!patent) {
-    throw new NotFoundException([`Not found patent with name "${name}""`]);
+    throw new NotFoundException([
+      `${ERRORS_NOT_FOUND.NOT_FOUND_PATENT_NAME} "${name}"`,
+    ]);
   }
   return patent;
 };

--- a/new-api/src/v2/modules/members/strategies/auth/local.strategy.ts
+++ b/new-api/src/v2/modules/members/strategies/auth/local.strategy.ts
@@ -17,7 +17,7 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
     });
 
     if (!member) {
-      throw new UnauthorizedException();
+      throw new UnauthorizedException(['Login/Email or password is incorrect']);
     }
     return member;
   }

--- a/new-api/src/v2/modules/members/strategies/auth/local.strategy.ts
+++ b/new-api/src/v2/modules/members/strategies/auth/local.strategy.ts
@@ -1,8 +1,9 @@
-import { Strategy } from 'passport-local';
-import { PassportStrategy } from '@nestjs/passport';
-import { Injectable, UnauthorizedException } from '@nestjs/common';
-import { ServiceAuth } from '../../services/auth.service';
 import { EntityMember } from '@modules/members/typeorm/entities/member.entity';
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ERRORS_UNAUTHORIZED } from '@utils/Errors/Unauthorized';
+import { Strategy } from 'passport-local';
+import { ServiceAuth } from '../../services/auth.service';
 
 @Injectable()
 export class LocalStrategy extends PassportStrategy(Strategy) {
@@ -17,7 +18,9 @@ export class LocalStrategy extends PassportStrategy(Strategy) {
     });
 
     if (!member) {
-      throw new UnauthorizedException(['Login/Email or password is incorrect']);
+      throw new UnauthorizedException([
+        ERRORS_UNAUTHORIZED.LOGIN_OR_EMAIL_INVALID,
+      ]);
     }
     return member;
   }

--- a/new-api/src/v2/modules/members/typeorm/repositories/member.repository.ts
+++ b/new-api/src/v2/modules/members/typeorm/repositories/member.repository.ts
@@ -1,3 +1,5 @@
+import IFindConflictDTO from '@modules/members/dtos/IFindConflict.dto';
+import { InternalServerErrorException } from '@nestjs/common';
 import { EntityRepository, getRepository, Like, Repository } from 'typeorm';
 import ICreateMemberDTO from '../../dtos/ICreateMember.dto';
 import IOrderByMember from '../../dtos/IOrderByMember.dto';
@@ -50,6 +52,18 @@ export class RepositoryMember
       .where('member.login = :login', { login });
 
     return members.getOne();
+  }
+
+  public async findConflict(
+    uniqueDatas: Partial<IFindConflictDTO>,
+  ): Promise<EntityMember | undefined> {
+    if (Object.keys(uniqueDatas).length === 0) {
+      throw new InternalServerErrorException([
+        'It should define  at least one attribute de uniqueDatas: email, login, linkedin, lattes, gitHub, quoteName',
+      ]);
+    }
+
+    return this.ormRepository.findOne({ where: { ...uniqueDatas } });
   }
 
   public async findByLikeName(

--- a/new-api/src/v2/modules/works/controllers/category.controller.ts
+++ b/new-api/src/v2/modules/works/controllers/category.controller.ts
@@ -43,7 +43,7 @@ import { EntityCategory } from '../typeorm/entities/category.entity';
 @UseInterceptors(ClassSerializerInterceptorPromise)
 @Controller(`${apiConfig.version}/works/categories`)
 export class ControllerCategory {
-  constructor(private readonly ServiceCategory: ServiceCategory) {}
+  constructor(private readonly serviceCategory: ServiceCategory) {}
 
   @ApiOperation({ summary: "Create Works's Categories" })
   @ApiCreatedResponse({
@@ -60,7 +60,7 @@ export class ControllerCategory {
   @UsePipes(new ValidationPipe())
   @Post()
   create(@Body() data: ICreateCategoryBasicDTO, @Req() request: any) {
-    return this.ServiceCategory.createCategory({
+    return this.serviceCategory.createCategory({
       newCategoryData: data,
       idMember: request.user.userId,
     });
@@ -84,7 +84,7 @@ export class ControllerCategory {
   @UsePipes(new ValidationPipe())
   @Get()
   findAll(@Query() order: ISelectOrderDTO) {
-    return this.ServiceCategory.findAll(order);
+    return this.serviceCategory.findAll(order);
   }
 
   @ApiOperation({ summary: "Find works's categories by name" })
@@ -99,6 +99,6 @@ export class ControllerCategory {
   @UsePipes(new ValidationPipe())
   @Get(':name')
   findOneByName(@Param() params: IFindOneCategoryByName) {
-    return this.ServiceCategory.findOneByName(params.name);
+    return this.serviceCategory.findOneByName(params.name);
   }
 }

--- a/new-api/src/v2/modules/works/services/areaExpertise.service.ts
+++ b/new-api/src/v2/modules/works/services/areaExpertise.service.ts
@@ -8,6 +8,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { ERRORS_UNAUTHORIZED } from '@utils/Errors/Unauthorized';
 import { ICreateAreaExpertiseDTO } from '../dtos/areaExpertise/ICreateAreaExpertise.dto';
 import IRepositoryAreaExpertise from '../repositories/IRepositoryAreaExpertise';
 import { EntityAreaExpertise } from '../typeorm/entities/areaExpertise.entity';
@@ -32,7 +33,9 @@ export class ServiceAreaExpertise {
       member = await this.serviceMember.findById(idMember);
     } catch (error) {
       if (error instanceof NotFoundException) {
-        throw new UnauthorizedException(['I need to be logged in']);
+        throw new UnauthorizedException([
+          ERRORS_UNAUTHORIZED.YOU_NEED_TO_BE_LOGGED_IN,
+        ]);
       }
       throw error;
     }

--- a/new-api/src/v2/modules/works/services/areaExpertise.service.ts
+++ b/new-api/src/v2/modules/works/services/areaExpertise.service.ts
@@ -2,7 +2,11 @@ import { ServiceMember } from '@modules/members/services/member.service';
 import IOrderByDTO, {
   ISelectOrderDTO,
 } from '@modules/shared/dtos/IOrderBy.dto';
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ICreateAreaExpertiseDTO } from '../dtos/areaExpertise/ICreateAreaExpertise.dto';
 import IRepositoryAreaExpertise from '../repositories/IRepositoryAreaExpertise';
@@ -22,10 +26,15 @@ export class ServiceAreaExpertise {
     newExpertiseAreaData,
     idMember,
   }: ICreateAreaExpertiseDTO): Promise<EntityAreaExpertise> {
-    const member = await this.serviceMember.findById(idMember);
+    let member;
 
-    if (!member) {
-      throw new UnauthorizedException(['I need to be logged in']);
+    try {
+      member = await this.serviceMember.findById(idMember);
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw new UnauthorizedException(['I need to be logged in']);
+      }
+      throw error;
     }
 
     return create({

--- a/new-api/src/v2/modules/works/services/areaExpertise/createAreaExpertise.service.spec.ts
+++ b/new-api/src/v2/modules/works/services/areaExpertise/createAreaExpertise.service.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '@nestjs/common';
 import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
+import FakeStorageProvider from '@providers/StorageProvider/implementations/fakes/FakeStorage.provider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 import { ServiceAreaExpertise } from '../areaExpertise.service';
 
@@ -18,7 +19,7 @@ let fakeRepositoryMember: FakeRepositoryMember;
 let fakeRepositoryExpertiseArea: FakeRepositoryAreaExpertise;
 
 let fakeHashProvider: IHashProvider;
-let iStorageProver: IStorageProvider;
+let fakeStorageProvider: IStorageProvider;
 
 let serviceMember: ServiceMember;
 let serviceExpertiseArea: ServiceAreaExpertise;
@@ -27,13 +28,16 @@ describe('Create ExpertiseArea - SERVICES', () => {
   beforeEach(() => {
     fakeRepositoryPatent = new FakeRepositoryPatent();
     fakeRepositoryMember = new FakeRepositoryMember();
-    fakeHashProvider = new FakeHashProvider();
     fakeRepositoryExpertiseArea = new FakeRepositoryAreaExpertise();
+
+    fakeHashProvider = new FakeHashProvider();
+    fakeStorageProvider = new FakeStorageProvider();
+
     serviceMember = new ServiceMember(
       fakeRepositoryMember,
       fakeRepositoryPatent,
       fakeHashProvider,
-      iStorageProver,
+      fakeStorageProvider,
     );
 
     serviceExpertiseArea = new ServiceAreaExpertise(

--- a/new-api/src/v2/modules/works/services/areaExpertise/createAreaExpertise.service.spec.ts
+++ b/new-api/src/v2/modules/works/services/areaExpertise/createAreaExpertise.service.spec.ts
@@ -8,6 +8,7 @@ import {
   ForbiddenException,
   UnauthorizedException,
 } from '@nestjs/common';
+import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 import { ServiceAreaExpertise } from '../areaExpertise.service';
@@ -16,7 +17,7 @@ let fakeRepositoryPatent: FakeRepositoryPatent;
 let fakeRepositoryMember: FakeRepositoryMember;
 let fakeRepositoryExpertiseArea: FakeRepositoryAreaExpertise;
 
-let iHashProvider: IHashProvider;
+let fakeHashProvider: IHashProvider;
 let iStorageProver: IStorageProvider;
 
 let serviceMember: ServiceMember;
@@ -26,11 +27,12 @@ describe('Create ExpertiseArea - SERVICES', () => {
   beforeEach(() => {
     fakeRepositoryPatent = new FakeRepositoryPatent();
     fakeRepositoryMember = new FakeRepositoryMember();
+    fakeHashProvider = new FakeHashProvider();
     fakeRepositoryExpertiseArea = new FakeRepositoryAreaExpertise();
     serviceMember = new ServiceMember(
       fakeRepositoryMember,
       fakeRepositoryPatent,
-      iHashProvider,
+      fakeHashProvider,
       iStorageProver,
     );
 

--- a/new-api/src/v2/modules/works/services/areaExpertise/createAreaExpertise.service.ts
+++ b/new-api/src/v2/modules/works/services/areaExpertise/createAreaExpertise.service.ts
@@ -18,7 +18,7 @@ const create = async ({
 }: IRequest): Promise<EntityAreaExpertise> => {
   if (!hasCreatePermission(member.patent.id)) {
     throw new ForbiddenException([
-      'Your patent not have permission for creating a new patent',
+      "Your patent don't have permission for creating a new patent",
     ]);
   }
 

--- a/new-api/src/v2/modules/works/services/areaExpertise/createAreaExpertise.service.ts
+++ b/new-api/src/v2/modules/works/services/areaExpertise/createAreaExpertise.service.ts
@@ -2,6 +2,7 @@ import { hasCreatePermission } from '@modules/members/enums/CREATION_PERMISSION_
 import { EntityMember } from '@modules/members/typeorm/entities/member.entity';
 import IRepositoryAreaExpertise from '@modules/works/repositories/IRepositoryAreaExpertise';
 import { ConflictException, ForbiddenException } from '@nestjs/common';
+import { ERRORS_FORBIDDEN } from '@utils/Errors/Forbidden';
 import ICreateAreaExpertiseDTO from '../../dtos/areaExpertise/ICreateAreaExpertise.dto';
 import { EntityAreaExpertise } from '../../typeorm/entities/areaExpertise.entity';
 
@@ -18,7 +19,7 @@ const create = async ({
 }: IRequest): Promise<EntityAreaExpertise> => {
   if (!hasCreatePermission(member.patent.id)) {
     throw new ForbiddenException([
-      "Your patent don't have permission for creating a new patent",
+      ERRORS_FORBIDDEN.PATENT_DONT_HAVE_PERMISSION_FOR_CREATE_AREA_EXPERTISE,
     ]);
   }
 

--- a/new-api/src/v2/modules/works/services/areaExpertise/findAreaExpertise.service.spec.ts
+++ b/new-api/src/v2/modules/works/services/areaExpertise/findAreaExpertise.service.spec.ts
@@ -4,6 +4,7 @@ import { ServiceMember } from '@modules/members/services/member.service';
 import { FakeRepositoryAreaExpertise } from '@modules/works/repositories/fakes/AreaExpertise.fakeRepository';
 import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
+import FakeStorageProvider from '@providers/StorageProvider/implementations/fakes/FakeStorage.provider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 import NoContentException from '../../../../utils/Exceptions/NoContent.exception';
 import { ServiceAreaExpertise } from '../areaExpertise.service';
@@ -13,7 +14,7 @@ let fakeRepositoryMember: FakeRepositoryMember;
 let fakeRepositoryAreaExpertise: FakeRepositoryAreaExpertise;
 
 let fakeHashProvider: IHashProvider;
-let iStorageProver: IStorageProvider;
+let fakeStorageProvider: IStorageProvider;
 
 let serviceMember: ServiceMember;
 let serviceAreaExpertise: ServiceAreaExpertise;
@@ -22,13 +23,16 @@ describe('Find all Categories - SERVICES', () => {
   beforeEach(() => {
     fakeRepositoryPatent = new FakeRepositoryPatent();
     fakeRepositoryMember = new FakeRepositoryMember();
-    fakeHashProvider = new FakeHashProvider();
     fakeRepositoryAreaExpertise = new FakeRepositoryAreaExpertise();
+
+    fakeHashProvider = new FakeHashProvider();
+    fakeStorageProvider = new FakeStorageProvider();
+
     serviceMember = new ServiceMember(
       fakeRepositoryMember,
       fakeRepositoryPatent,
       fakeHashProvider,
-      iStorageProver,
+      fakeStorageProvider,
     );
 
     serviceAreaExpertise = new ServiceAreaExpertise(

--- a/new-api/src/v2/modules/works/services/areaExpertise/findAreaExpertise.service.spec.ts
+++ b/new-api/src/v2/modules/works/services/areaExpertise/findAreaExpertise.service.spec.ts
@@ -2,6 +2,7 @@ import { FakeRepositoryMember } from '@modules/members/repositories/fakes/Member
 import { FakeRepositoryPatent } from '@modules/members/repositories/fakes/Patent.fakeRepository';
 import { ServiceMember } from '@modules/members/services/member.service';
 import { FakeRepositoryAreaExpertise } from '@modules/works/repositories/fakes/AreaExpertise.fakeRepository';
+import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 import NoContentException from '../../../../utils/Exceptions/NoContent.exception';
@@ -11,7 +12,7 @@ let fakeRepositoryPatent: FakeRepositoryPatent;
 let fakeRepositoryMember: FakeRepositoryMember;
 let fakeRepositoryAreaExpertise: FakeRepositoryAreaExpertise;
 
-let iHashProvider: IHashProvider;
+let fakeHashProvider: IHashProvider;
 let iStorageProver: IStorageProvider;
 
 let serviceMember: ServiceMember;
@@ -21,11 +22,12 @@ describe('Find all Categories - SERVICES', () => {
   beforeEach(() => {
     fakeRepositoryPatent = new FakeRepositoryPatent();
     fakeRepositoryMember = new FakeRepositoryMember();
+    fakeHashProvider = new FakeHashProvider();
     fakeRepositoryAreaExpertise = new FakeRepositoryAreaExpertise();
     serviceMember = new ServiceMember(
       fakeRepositoryMember,
       fakeRepositoryPatent,
-      iHashProvider,
+      fakeHashProvider,
       iStorageProver,
     );
 

--- a/new-api/src/v2/modules/works/services/category.service.ts
+++ b/new-api/src/v2/modules/works/services/category.service.ts
@@ -8,6 +8,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { ERRORS_UNAUTHORIZED } from '@utils/Errors/Unauthorized';
 import { ICreateCategoryDTO } from '../dtos/category/ICreateCategory.dto';
 import IRepositoryCategory from '../repositories/IRepositoryCategory';
 import { EntityCategory } from '../typeorm/entities/category.entity';
@@ -32,7 +33,9 @@ export class ServiceCategory {
       member = await this.serviceMember.findById(idMember);
     } catch (error) {
       if (error instanceof NotFoundException) {
-        throw new UnauthorizedException(['I need to be logged in']);
+        throw new UnauthorizedException([
+          ERRORS_UNAUTHORIZED.YOU_NEED_TO_BE_LOGGED_IN,
+        ]);
       }
       throw error;
     }

--- a/new-api/src/v2/modules/works/services/category.service.ts
+++ b/new-api/src/v2/modules/works/services/category.service.ts
@@ -2,7 +2,11 @@ import { ServiceMember } from '@modules/members/services/member.service';
 import IOrderByDTO, {
   ISelectOrderDTO,
 } from '@modules/shared/dtos/IOrderBy.dto';
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ICreateCategoryDTO } from '../dtos/category/ICreateCategory.dto';
 import IRepositoryCategory from '../repositories/IRepositoryCategory';
@@ -22,10 +26,15 @@ export class ServiceCategory {
     newCategoryData,
     idMember,
   }: ICreateCategoryDTO): Promise<EntityCategory> {
-    const member = await this.serviceMember.findById(idMember);
+    let member;
 
-    if (!member) {
-      throw new UnauthorizedException(['I need to be logged in']);
+    try {
+      member = await this.serviceMember.findById(idMember);
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw new UnauthorizedException(['I need to be logged in']);
+      }
+      throw error;
     }
 
     return services.create({

--- a/new-api/src/v2/modules/works/services/category/createCategory.service.spec.ts
+++ b/new-api/src/v2/modules/works/services/category/createCategory.service.spec.ts
@@ -8,6 +8,7 @@ import {
   ForbiddenException,
   UnauthorizedException,
 } from '@nestjs/common';
+import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 import { ServiceCategory } from '../category.service';
@@ -16,7 +17,7 @@ let fakeRepositoryPatent: FakeRepositoryPatent;
 let fakeRepositoryMember: FakeRepositoryMember;
 let fakeRepositoryCategory: FakeRepositoryCategory;
 
-let iHashProvider: IHashProvider;
+let fakeHashProvider: IHashProvider;
 let iStorageProver: IStorageProvider;
 
 let serviceMember: ServiceMember;
@@ -26,11 +27,12 @@ describe('Create Category - SERVICES', () => {
   beforeEach(() => {
     fakeRepositoryPatent = new FakeRepositoryPatent();
     fakeRepositoryMember = new FakeRepositoryMember();
+    fakeHashProvider = new FakeHashProvider();
     fakeRepositoryCategory = new FakeRepositoryCategory();
     serviceMember = new ServiceMember(
       fakeRepositoryMember,
       fakeRepositoryPatent,
-      iHashProvider,
+      fakeHashProvider,
       iStorageProver,
     );
 

--- a/new-api/src/v2/modules/works/services/category/createCategory.service.spec.ts
+++ b/new-api/src/v2/modules/works/services/category/createCategory.service.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '@nestjs/common';
 import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
+import FakeStorageProvider from '@providers/StorageProvider/implementations/fakes/FakeStorage.provider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 import { ServiceCategory } from '../category.service';
 
@@ -18,7 +19,7 @@ let fakeRepositoryMember: FakeRepositoryMember;
 let fakeRepositoryCategory: FakeRepositoryCategory;
 
 let fakeHashProvider: IHashProvider;
-let iStorageProver: IStorageProvider;
+let fakeStorageProvider: IStorageProvider;
 
 let serviceMember: ServiceMember;
 let serviceCategory: ServiceCategory;
@@ -27,13 +28,16 @@ describe('Create Category - SERVICES', () => {
   beforeEach(() => {
     fakeRepositoryPatent = new FakeRepositoryPatent();
     fakeRepositoryMember = new FakeRepositoryMember();
-    fakeHashProvider = new FakeHashProvider();
     fakeRepositoryCategory = new FakeRepositoryCategory();
+
+    fakeHashProvider = new FakeHashProvider();
+    fakeStorageProvider = new FakeStorageProvider();
+
     serviceMember = new ServiceMember(
       fakeRepositoryMember,
       fakeRepositoryPatent,
       fakeHashProvider,
-      iStorageProver,
+      fakeStorageProvider,
     );
 
     serviceCategory = new ServiceCategory(

--- a/new-api/src/v2/modules/works/services/category/createCategory.service.ts
+++ b/new-api/src/v2/modules/works/services/category/createCategory.service.ts
@@ -18,7 +18,7 @@ const create = async ({
 }: IRequest): Promise<EntityCategory> => {
   if (!hasCreatePermission(member.patent.id)) {
     throw new ForbiddenException([
-      'Your patent not have permission for creating a new patent',
+      "Your patent don't have permission for creating a new patent",
     ]);
   }
 

--- a/new-api/src/v2/modules/works/services/category/createCategory.service.ts
+++ b/new-api/src/v2/modules/works/services/category/createCategory.service.ts
@@ -4,6 +4,7 @@ import ICreateCategoryDTO from '@modules/works/dtos/category/ICreateCategory.dto
 import IRepositoryCategory from '@modules/works/repositories/IRepositoryCategory';
 import { EntityCategory } from '@modules/works/typeorm/entities/category.entity';
 import { ConflictException, ForbiddenException } from '@nestjs/common';
+import { ERRORS_FORBIDDEN } from '@utils/Errors/Forbidden';
 
 interface IRequest {
   newCategoryData: ICreateCategoryDTO;
@@ -18,7 +19,7 @@ const create = async ({
 }: IRequest): Promise<EntityCategory> => {
   if (!hasCreatePermission(member.patent.id)) {
     throw new ForbiddenException([
-      "Your patent don't have permission for creating a new patent",
+      ERRORS_FORBIDDEN.PATENT_DONT_HAVE_PERMISSION_FOR_CREATE_CATEGORY,
     ]);
   }
 

--- a/new-api/src/v2/modules/works/services/category/findAllCategory.service.spec.ts
+++ b/new-api/src/v2/modules/works/services/category/findAllCategory.service.spec.ts
@@ -4,6 +4,7 @@ import { ServiceMember } from '@modules/members/services/member.service';
 import { FakeRepositoryCategory } from '@modules/works/repositories/fakes/Category.fakeRepository';
 import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
+import FakeStorageProvider from '@providers/StorageProvider/implementations/fakes/FakeStorage.provider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 import NoContentException from '../../../../utils/Exceptions/NoContent.exception';
 import { ServiceCategory } from '../category.service';
@@ -13,7 +14,7 @@ let fakeRepositoryMember: FakeRepositoryMember;
 let fakeRepositoryCategory: FakeRepositoryCategory;
 
 let fakeHashProvider: IHashProvider;
-let iStorageProver: IStorageProvider;
+let fakeStorageProvider: IStorageProvider;
 
 let serviceMember: ServiceMember;
 let serviceCategory: ServiceCategory;
@@ -22,13 +23,16 @@ describe('Find all Categories - SERVICES', () => {
   beforeEach(() => {
     fakeRepositoryPatent = new FakeRepositoryPatent();
     fakeRepositoryMember = new FakeRepositoryMember();
-    fakeHashProvider = new FakeHashProvider();
     fakeRepositoryCategory = new FakeRepositoryCategory();
+
+    fakeHashProvider = new FakeHashProvider();
+    fakeStorageProvider = new FakeStorageProvider();
+
     serviceMember = new ServiceMember(
       fakeRepositoryMember,
       fakeRepositoryPatent,
       fakeHashProvider,
-      iStorageProver,
+      fakeStorageProvider,
     );
 
     serviceCategory = new ServiceCategory(

--- a/new-api/src/v2/modules/works/services/category/findAllCategory.service.spec.ts
+++ b/new-api/src/v2/modules/works/services/category/findAllCategory.service.spec.ts
@@ -2,6 +2,7 @@ import { FakeRepositoryMember } from '@modules/members/repositories/fakes/Member
 import { FakeRepositoryPatent } from '@modules/members/repositories/fakes/Patent.fakeRepository';
 import { ServiceMember } from '@modules/members/services/member.service';
 import { FakeRepositoryCategory } from '@modules/works/repositories/fakes/Category.fakeRepository';
+import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 import NoContentException from '../../../../utils/Exceptions/NoContent.exception';
@@ -11,7 +12,7 @@ let fakeRepositoryPatent: FakeRepositoryPatent;
 let fakeRepositoryMember: FakeRepositoryMember;
 let fakeRepositoryCategory: FakeRepositoryCategory;
 
-let iHashProvider: IHashProvider;
+let fakeHashProvider: IHashProvider;
 let iStorageProver: IStorageProvider;
 
 let serviceMember: ServiceMember;
@@ -21,11 +22,12 @@ describe('Find all Categories - SERVICES', () => {
   beforeEach(() => {
     fakeRepositoryPatent = new FakeRepositoryPatent();
     fakeRepositoryMember = new FakeRepositoryMember();
+    fakeHashProvider = new FakeHashProvider();
     fakeRepositoryCategory = new FakeRepositoryCategory();
     serviceMember = new ServiceMember(
       fakeRepositoryMember,
       fakeRepositoryPatent,
-      iHashProvider,
+      fakeHashProvider,
       iStorageProver,
     );
 

--- a/new-api/src/v2/modules/works/services/category/findOneCategoryByName.service.ts
+++ b/new-api/src/v2/modules/works/services/category/findOneCategoryByName.service.ts
@@ -1,6 +1,7 @@
 import IRepositoryCategory from '@modules/works/repositories/IRepositoryCategory';
 import { EntityCategory } from '@modules/works/typeorm/entities/category.entity';
 import { NotFoundException } from '@nestjs/common';
+import { ERRORS_NOT_FOUND } from '@utils/Errors/NotFound';
 
 interface IRequest {
   repository: IRepositoryCategory;
@@ -14,7 +15,9 @@ const findOneCategoryByName = async ({
   const category = await repository.findByName(name);
 
   if (!category) {
-    throw new NotFoundException([`Not found category with name "${name}""`]);
+    throw new NotFoundException([
+      `${ERRORS_NOT_FOUND.NOT_FOUND_CATEGORY_NAME} "${name}""`,
+    ]);
   }
 
   return category;

--- a/new-api/src/v2/modules/works/services/type.service.ts
+++ b/new-api/src/v2/modules/works/services/type.service.ts
@@ -8,6 +8,7 @@ import {
   UnauthorizedException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { ERRORS_UNAUTHORIZED } from '@utils/Errors/Unauthorized';
 import { ICreateTypeDTO } from '../dtos/type/ICreateType.dto';
 import IRepositoryType from '../repositories/IRepositoryType';
 import { EntityType } from '../typeorm/entities/type.entity';
@@ -32,7 +33,9 @@ export class ServiceType {
       member = await this.serviceMember.findById(idMember);
     } catch (error) {
       if (error instanceof NotFoundException) {
-        throw new UnauthorizedException(['I need to be logged in']);
+        throw new UnauthorizedException([
+          ERRORS_UNAUTHORIZED.YOU_NEED_TO_BE_LOGGED_IN,
+        ]);
       }
       throw error;
     }

--- a/new-api/src/v2/modules/works/services/type.service.ts
+++ b/new-api/src/v2/modules/works/services/type.service.ts
@@ -2,7 +2,11 @@ import { ServiceMember } from '@modules/members/services/member.service';
 import IOrderByDTO, {
   ISelectOrderDTO,
 } from '@modules/shared/dtos/IOrderBy.dto';
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import {
+  Injectable,
+  NotFoundException,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { ICreateTypeDTO } from '../dtos/type/ICreateType.dto';
 import IRepositoryType from '../repositories/IRepositoryType';
@@ -22,10 +26,15 @@ export class ServiceType {
     newTypeData,
     idMember,
   }: ICreateTypeDTO): Promise<EntityType> {
-    const member = await this.serviceMember.findById(idMember);
+    let member;
 
-    if (!member) {
-      throw new UnauthorizedException(['I need to be logged in']);
+    try {
+      member = await this.serviceMember.findById(idMember);
+    } catch (error) {
+      if (error instanceof NotFoundException) {
+        throw new UnauthorizedException(['I need to be logged in']);
+      }
+      throw error;
     }
 
     return create({

--- a/new-api/src/v2/modules/works/services/type/createType.service.spec.ts
+++ b/new-api/src/v2/modules/works/services/type/createType.service.spec.ts
@@ -10,6 +10,7 @@ import {
 } from '@nestjs/common';
 import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
+import FakeStorageProvider from '@providers/StorageProvider/implementations/fakes/FakeStorage.provider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 import { ServiceType } from '../type.service';
 
@@ -18,7 +19,7 @@ let fakeRepositoryMember: FakeRepositoryMember;
 let fakeRepositoryType: FakeRepositoryType;
 
 let fakeHashProvider: IHashProvider;
-let iStorageProver: IStorageProvider;
+let fakeStorageProvider: IStorageProvider;
 
 let serviceMember: ServiceMember;
 let serviceType: ServiceType;
@@ -27,14 +28,16 @@ describe('Create Type - SERVICES', () => {
   beforeEach(() => {
     fakeRepositoryPatent = new FakeRepositoryPatent();
     fakeRepositoryMember = new FakeRepositoryMember();
+    fakeRepositoryType = new FakeRepositoryType();
 
     fakeHashProvider = new FakeHashProvider();
-    fakeRepositoryType = new FakeRepositoryType();
+    fakeStorageProvider = new FakeStorageProvider();
+
     serviceMember = new ServiceMember(
       fakeRepositoryMember,
       fakeRepositoryPatent,
       fakeHashProvider,
-      iStorageProver,
+      fakeStorageProvider,
     );
 
     serviceType = new ServiceType(fakeRepositoryType, serviceMember);

--- a/new-api/src/v2/modules/works/services/type/createType.service.spec.ts
+++ b/new-api/src/v2/modules/works/services/type/createType.service.spec.ts
@@ -8,6 +8,7 @@ import {
   ForbiddenException,
   UnauthorizedException,
 } from '@nestjs/common';
+import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 import { ServiceType } from '../type.service';
@@ -16,7 +17,7 @@ let fakeRepositoryPatent: FakeRepositoryPatent;
 let fakeRepositoryMember: FakeRepositoryMember;
 let fakeRepositoryType: FakeRepositoryType;
 
-let iHashProvider: IHashProvider;
+let fakeHashProvider: IHashProvider;
 let iStorageProver: IStorageProvider;
 
 let serviceMember: ServiceMember;
@@ -26,11 +27,13 @@ describe('Create Type - SERVICES', () => {
   beforeEach(() => {
     fakeRepositoryPatent = new FakeRepositoryPatent();
     fakeRepositoryMember = new FakeRepositoryMember();
+
+    fakeHashProvider = new FakeHashProvider();
     fakeRepositoryType = new FakeRepositoryType();
     serviceMember = new ServiceMember(
       fakeRepositoryMember,
       fakeRepositoryPatent,
-      iHashProvider,
+      fakeHashProvider,
       iStorageProver,
     );
 

--- a/new-api/src/v2/modules/works/services/type/createType.service.ts
+++ b/new-api/src/v2/modules/works/services/type/createType.service.ts
@@ -18,7 +18,7 @@ const create = async ({
 }: IRequest): Promise<EntityType> => {
   if (!hasCreatePermission(member.patent.id)) {
     throw new ForbiddenException([
-      'Your patent not have permission for creating a new patent',
+      "Your patent don't have permission for creating a new patent",
     ]);
   }
 

--- a/new-api/src/v2/modules/works/services/type/createType.service.ts
+++ b/new-api/src/v2/modules/works/services/type/createType.service.ts
@@ -4,6 +4,7 @@ import IRepositoryType from '../../repositories/IRepositoryType';
 import { EntityType } from '../../typeorm/entities/type.entity';
 import { EntityMember } from '@modules/members/typeorm/entities/member.entity';
 import { hasCreatePermission } from '@modules/members/enums/CREATION_PERMISSION_PATENTS';
+import { ERRORS_FORBIDDEN } from '@utils/Errors/Forbidden';
 
 interface IRequest {
   newTypeData: ICreateTypeDTO;
@@ -18,7 +19,7 @@ const create = async ({
 }: IRequest): Promise<EntityType> => {
   if (!hasCreatePermission(member.patent.id)) {
     throw new ForbiddenException([
-      "Your patent don't have permission for creating a new patent",
+      ERRORS_FORBIDDEN.PATENT_DONT_HAVE_PERMISSION_FOR_CREATE_TYPE,
     ]);
   }
 

--- a/new-api/src/v2/modules/works/services/type/findAllType.service.spec.ts
+++ b/new-api/src/v2/modules/works/services/type/findAllType.service.spec.ts
@@ -4,6 +4,7 @@ import { ServiceMember } from '@modules/members/services/member.service';
 import { FakeRepositoryType } from '@modules/works/repositories/fakes/Type.fakeRepository';
 import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
+import FakeStorageProvider from '@providers/StorageProvider/implementations/fakes/FakeStorage.provider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 import NoContentException from '../../../../utils/Exceptions/NoContent.exception';
 import { ServiceType } from '../type.service';
@@ -13,7 +14,7 @@ let fakeRepositoryMember: FakeRepositoryMember;
 let fakeRepositoryType: FakeRepositoryType;
 
 let fakeHashProvider: IHashProvider;
-let iStorageProver: IStorageProvider;
+let fakeStorageProvider: IStorageProvider;
 
 let serviceMember: ServiceMember;
 let serviceType: ServiceType;
@@ -22,13 +23,16 @@ describe('Find all Types - SERVICES', () => {
   beforeEach(() => {
     fakeRepositoryPatent = new FakeRepositoryPatent();
     fakeRepositoryMember = new FakeRepositoryMember();
-    fakeHashProvider = new FakeHashProvider();
     fakeRepositoryType = new FakeRepositoryType();
+
+    fakeHashProvider = new FakeHashProvider();
+    fakeStorageProvider = new FakeStorageProvider();
+
     serviceMember = new ServiceMember(
       fakeRepositoryMember,
       fakeRepositoryPatent,
       fakeHashProvider,
-      iStorageProver,
+      fakeStorageProvider,
     );
 
     serviceType = new ServiceType(fakeRepositoryType, serviceMember);

--- a/new-api/src/v2/modules/works/services/type/findAllType.service.spec.ts
+++ b/new-api/src/v2/modules/works/services/type/findAllType.service.spec.ts
@@ -2,6 +2,7 @@ import { FakeRepositoryMember } from '@modules/members/repositories/fakes/Member
 import { FakeRepositoryPatent } from '@modules/members/repositories/fakes/Patent.fakeRepository';
 import { ServiceMember } from '@modules/members/services/member.service';
 import { FakeRepositoryType } from '@modules/works/repositories/fakes/Type.fakeRepository';
+import FakeHashProvider from '@providers/HashProvider/implementations/fakes/FakeHashProvider';
 import IHashProvider from '@providers/HashProvider/models/IHashProvider';
 import IStorageProvider from '@providers/StorageProvider/models/IStorageProvider';
 import NoContentException from '../../../../utils/Exceptions/NoContent.exception';
@@ -11,7 +12,7 @@ let fakeRepositoryPatent: FakeRepositoryPatent;
 let fakeRepositoryMember: FakeRepositoryMember;
 let fakeRepositoryType: FakeRepositoryType;
 
-let iHashProvider: IHashProvider;
+let fakeHashProvider: IHashProvider;
 let iStorageProver: IStorageProvider;
 
 let serviceMember: ServiceMember;
@@ -21,11 +22,12 @@ describe('Find all Types - SERVICES', () => {
   beforeEach(() => {
     fakeRepositoryPatent = new FakeRepositoryPatent();
     fakeRepositoryMember = new FakeRepositoryMember();
+    fakeHashProvider = new FakeHashProvider();
     fakeRepositoryType = new FakeRepositoryType();
     serviceMember = new ServiceMember(
       fakeRepositoryMember,
       fakeRepositoryPatent,
-      iHashProvider,
+      fakeHashProvider,
       iStorageProver,
     );
 

--- a/new-api/src/v2/modules/works/services/work.service.ts
+++ b/new-api/src/v2/modules/works/services/work.service.ts
@@ -1,6 +1,7 @@
 import { ServiceMember } from '@modules/members/services/member.service';
 import { Injectable, UnauthorizedException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { ERRORS_UNAUTHORIZED } from '@utils/Errors/Unauthorized';
 import { ICreateWorkDTO } from '../dtos/work/ICreateWork.dto';
 import IOrderWorkDTO, {
   ISelectOrderWorkDTO,
@@ -27,7 +28,9 @@ export class ServiceWork {
     const member = await this.serviceMember.findById(idMember);
 
     if (!member) {
-      throw new UnauthorizedException(['I need to be logged in']);
+      throw new UnauthorizedException([
+        ERRORS_UNAUTHORIZED.YOU_NEED_TO_BE_LOGGED_IN,
+      ]);
     }
 
     return create({

--- a/new-api/src/v2/modules/works/services/work/createWork.service.ts
+++ b/new-api/src/v2/modules/works/services/work/createWork.service.ts
@@ -18,7 +18,7 @@ const create = async ({
 }: IRequest): Promise<EntityWork> => {
   if (!hasCreatePermission(member.patent.id)) {
     throw new ForbiddenException([
-      'Your patent not have permission for creating a new work',
+      "Your patent don't have permission for creating a new work",
     ]);
   }
 

--- a/new-api/src/v2/modules/works/services/work/createWork.service.ts
+++ b/new-api/src/v2/modules/works/services/work/createWork.service.ts
@@ -1,6 +1,7 @@
 import { hasCreatePermission } from '@modules/members/enums/CREATION_PERMISSION_PATENTS';
 import { EntityMember } from '@modules/members/typeorm/entities/member.entity';
 import { ForbiddenException } from '@nestjs/common';
+import { ERRORS_FORBIDDEN } from '@utils/Errors/Forbidden';
 import ICreateWorkDTO from '../../dtos/work/ICreateWork.dto';
 import IRepositoryWork from '../../repositories/IRepositoryWork';
 import { EntityWork } from '../../typeorm/entities/work.entity';
@@ -18,7 +19,7 @@ const create = async ({
 }: IRequest): Promise<EntityWork> => {
   if (!hasCreatePermission(member.patent.id)) {
     throw new ForbiddenException([
-      "Your patent don't have permission for creating a new work",
+      ERRORS_FORBIDDEN.PATENT_DONT_HAVE_PERMISSION_FOR_CREATE_WORK,
     ]);
   }
 

--- a/new-api/src/v2/modules/works/services/work/findWorkBySlug.service.ts
+++ b/new-api/src/v2/modules/works/services/work/findWorkBySlug.service.ts
@@ -1,6 +1,7 @@
 import IRepositoryWork from '@modules/works/repositories/IRepositoryWork';
 import { EntityWork } from '@modules/works/typeorm/entities/work.entity';
 import { NotFoundException } from '@nestjs/common';
+import { ERRORS_NOT_FOUND } from '@utils/Errors/NotFound';
 
 interface IRequest {
   repository: IRepositoryWork;
@@ -14,7 +15,9 @@ const findWorkBySlug = async ({
   const work = await repository.findBySlug(slug);
 
   if (!work) {
-    throw new NotFoundException('Not found work');
+    throw new NotFoundException([
+      `${ERRORS_NOT_FOUND.NOT_FOUND_WORK_SLUG} "${slug}"`,
+    ]);
   }
   return work;
 };

--- a/new-api/src/v2/providers/HashProvider/implementations/fakes/FakeHashProvider.ts
+++ b/new-api/src/v2/providers/HashProvider/implementations/fakes/FakeHashProvider.ts
@@ -1,0 +1,11 @@
+import IHashProvider from '../../models/IHashProvider';
+
+export default class FakeHashProvider implements IHashProvider {
+  public async generateHash(payload: string): Promise<string> {
+    return payload;
+  }
+
+  public async compareHash(payload: string, hashed: string): Promise<boolean> {
+    return payload === hashed;
+  }
+}

--- a/new-api/src/v2/providers/StorageProvider/implementations/fakes/FakeStorage.provider.ts
+++ b/new-api/src/v2/providers/StorageProvider/implementations/fakes/FakeStorage.provider.ts
@@ -1,0 +1,33 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import uploadConfig from '@config/upload';
+import { InternalServerErrorException } from '@nestjs/common';
+import * as fs from 'fs';
+import { resolve } from 'path';
+import ILocationFileDTO from '../../dtos/ILocationFile.dto';
+import IStorageProvider from '../../models/IStorageProvider';
+
+export default class FakeStorageProvider implements IStorageProvider {
+  public async saveFile({
+    fileName,
+    targetFolder,
+    subFolders = [],
+  }: ILocationFileDTO): Promise<string> {
+    return `fakeName-${fileName}`;
+  }
+
+  public async deleteFile({
+    fileName,
+    targetFolder,
+    subFolders = [],
+  }: ILocationFileDTO): Promise<void> {
+    return;
+  }
+
+  public async getUrl({
+    fileName,
+    targetFolder,
+    subFolders = [],
+  }: ILocationFileDTO): Promise<string> {
+    return `fakeURL-${fileName}`;
+  }
+}

--- a/new-api/src/v2/utils/Errors/Forbidden.ts
+++ b/new-api/src/v2/utils/Errors/Forbidden.ts
@@ -1,23 +1,71 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+export enum ERRORS_FORBIDDEN {
+  FORBIDDEN = 'FORBIDDEN',
+  PATENT_DONT_HAVE_PERMISSION_FOR_CREATE_MEMBER = "Your patent don't have permission for creating a new member",
+  PATENT_DONT_HAVE_PERMISSION_FOR_UPDATE_MEMBER = "Your patent don't have permission for update member",
+  PATENT_DONT_HAVE_PERMISSION_FOR_DELETE_MEMBER = "Your patent don't have permission for deleting a member",
+  PATENT_DONT_HAVE_PERMISSION_FOR_CREATE_PATENT = "Your patent don't have permission for creating a new patent",
+  PATENT_DONT_HAVE_PERMISSION_FOR_UPDATE_PATENT = "Your patent don't have permission for update patent",
+  PATENT_DONT_HAVE_PERMISSION_FOR_DELETE_PATENT = "Your patent don't have permission for deleting a patent",
+  PATENT_DONT_HAVE_PERMISSION_FOR_CREATE_CATEGORY = "Your patent don't have permission for creating a new category",
+  PATENT_DONT_HAVE_PERMISSION_FOR_UPDATE_CATEGORY = "Your patent don't have permission for update category",
+  PATENT_DONT_HAVE_PERMISSION_FOR_DELETE_CATEGORY = "Your patent don't have permission for deleting a category",
+  PATENT_DONT_HAVE_PERMISSION_FOR_CREATE_TYPE = "Your patent don't have permission for creating a new type",
+  PATENT_DONT_HAVE_PERMISSION_FOR_UPDATE_TYPE = "Your patent don't have permission for update type",
+  PATENT_DONT_HAVE_PERMISSION_FOR_DELETE_TYPE = "Your patent don't have permission for deleting a type",
+  PATENT_DONT_HAVE_PERMISSION_FOR_CREATE_WORK = "Your patent don't have permission for creating a new work",
+  PATENT_DONT_HAVE_PERMISSION_FOR_UPDATE_WORK = "Your patent don't have permission for update work",
+  PATENT_DONT_HAVE_PERMISSION_FOR_DELETE_WORK = "Your patent don't have permission for deleting a work",
+  PATENT_DONT_HAVE_PERMISSION_FOR_CREATE_AREA_EXPERTISE = "Your patent don't have permission for creating a new area expertise",
+  PATENT_DONT_HAVE_PERMISSION_FOR_UPDATE_AREA_EXPERTISE = "Your patent don't have permission for update area expertise",
+  PATENT_DONT_HAVE_PERMISSION_FOR_DELETE_AREA_EXPERTISE = "Your patent don't have permission for deleting a area expertise",
+}
+
 export class Forbidden {
   @ApiProperty({
-    default: 403,
-    description: 'HTTP Status Code',
+    type: 'string',
+    description: 'Date and time the request was made',
+    example: '2022-01-24T23:34:16.687Z',
   })
-  statusCode: 403;
+  timeStamp: string;
 
   @ApiProperty({
-    example: 'Without permission',
-    description: 'Error messages',
+    type: 'string',
+    description: 'Path the request was made',
   })
-  message: string;
+  path: string;
 
   @ApiProperty({
-    example: 'Forbidden',
-    description: 'Type Error',
+    type: 'string',
+    description: 'HTTP status code number',
+    default: '403',
   })
-  error: string;
+  statusCode: number;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'HTTP status code name',
+    default: 'FORBIDDEN',
+  })
+  errorMessage: string;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'Method the request was made',
+    enum: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'],
+  })
+  method: string;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'errors or error found',
+    enum: [
+      ERRORS_FORBIDDEN.FORBIDDEN,
+      Object.values(ERRORS_FORBIDDEN).splice(1),
+    ],
+  })
+  errors: string | string[];
 }
 
 export default {

--- a/new-api/src/v2/utils/Errors/NotFound.ts
+++ b/new-api/src/v2/utils/Errors/NotFound.ts
@@ -1,27 +1,61 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+export enum ERRORS_NOT_FOUND {
+  NOT_FOUND = 'NOT FOUND',
+  NOT_FOUND_LOGIN = 'Not found member with login',
+  NOT_FOUND_ID = 'Not found member with id',
+  NOT_FOUND_PATENT_NAME = 'Not found patent with name',
+  NOT_FOUND_CATEGORY_NAME = 'Not found category with name',
+  NOT_FOUND_WORK_SLUG = 'Not found work with slug',
+}
+
 export class NotFound {
   @ApiProperty({
-    default: 404,
-    description: 'HTTP Status Code',
+    type: 'string',
+    description: 'Date and time the request was made',
+    example: '2022-01-24T23:34:16.687Z',
   })
-  statusCode: 404;
+  timeStamp: string;
 
   @ApiProperty({
-    example: ['not found'],
-    description: 'Error messages',
-    isArray: true,
+    type: 'string',
+    description: 'Path the request was made',
   })
-  message: string;
+  path: string;
 
   @ApiProperty({
-    default: 'NotFound',
-    description: 'Not found',
+    type: 'string',
+    description: 'HTTP status code number',
+    default: '404',
   })
-  error: 'NotFound';
+  statusCode: number;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'HTTP status code name',
+    default: 'NOT FOUND',
+  })
+  errorMessage: string;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'Method the request was made',
+    enum: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'],
+  })
+  method: string;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'errors or error found',
+    enum: [
+      ERRORS_NOT_FOUND.NOT_FOUND,
+      Object.values(ERRORS_NOT_FOUND).splice(1),
+    ],
+  })
+  errors: string | string[];
 }
 
 export default {
-  description: "Not found - Don't exists data",
+  description: "NOT FOUND - Don't exists data",
   type: NotFound,
 };

--- a/new-api/src/v2/utils/Errors/Unauthorized.ts
+++ b/new-api/src/v2/utils/Errors/Unauthorized.ts
@@ -1,20 +1,59 @@
 import { ApiProperty } from '@nestjs/swagger';
 
+export enum ERRORS_UNAUTHORIZED {
+  UNAUTHORIZED = 'Unauthorized',
+  YOU_NEED_TO_BE_LOGGED_IN = 'You must be logged in with a valid member',
+  OLD_TOKEN_INVALID = 'oldToken is not valid',
+  LOGIN_OR_EMAIL_INVALID = 'Login/Email or password is incorrect',
+}
+
 export class Unauthorized {
   @ApiProperty({
-    default: 401,
-    description: 'HTTP Status Code',
+    type: 'string',
+    description: 'Date and time the request was made',
+    example: '2022-01-24T23:34:16.687Z',
   })
-  statusCode: 401;
+  timeStamp: string;
 
   @ApiProperty({
-    example: 'Unauthorized',
-    description: 'Error messages',
+    type: 'string',
+    description: 'Path the request was made',
   })
-  message: string;
+  path: string;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'HTTP status code number',
+    default: '401',
+  })
+  statusCode: number;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'HTTP status code name',
+    default: 'UNAUTHORIZED',
+  })
+  errorMessage: string;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'Method the request was made',
+    enum: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'],
+  })
+  method: string;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'errors or error found',
+    enum: [
+      ERRORS_UNAUTHORIZED.UNAUTHORIZED,
+      Object.values(ERRORS_UNAUTHORIZED).splice(1),
+    ],
+  })
+  errors: string | string[];
 }
 
 export default {
-  description: 'Unauthorized',
+  description: 'UNAUTHORIZED',
   type: Unauthorized,
 };

--- a/new-api/src/v2/utils/Errors/UnprocessableEntity.ts
+++ b/new-api/src/v2/utils/Errors/UnprocessableEntity.ts
@@ -1,0 +1,57 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export enum ERRORS_UNPROCESSABLE_ENTITY {
+  UNPROCESSABLE_ENTITY = 'Unprocessable Entity',
+  DEFAULT_PASSWORD_NOT_DEFINED = "Member's default password not defined",
+}
+
+export class UnprocessableEntity {
+  @ApiProperty({
+    type: 'string',
+    description: 'Date and time the request was made',
+    example: '2022-01-24T23:34:16.687Z',
+  })
+  timeStamp: string;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'Path the request was made',
+  })
+  path: string;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'HTTP status code number',
+    default: '422',
+  })
+  statusCode: number;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'HTTP status code name',
+    default: 'UNPROCESSABLE ENTITY',
+  })
+  errorMessage: string;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'Method the request was made',
+    enum: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH'],
+  })
+  method: string;
+
+  @ApiProperty({
+    type: 'string',
+    description: 'errors or error found',
+    enum: [
+      ERRORS_UNPROCESSABLE_ENTITY.UNPROCESSABLE_ENTITY,
+      Object.values(ERRORS_UNPROCESSABLE_ENTITY).splice(1),
+    ],
+  })
+  errors: string | string[];
+}
+
+export default {
+  description: 'UNPROCESSABLE ENTITY',
+  type: UnprocessableEntity,
+};

--- a/new-api/src/v2/utils/Errors/index.ts
+++ b/new-api/src/v2/utils/Errors/index.ts
@@ -4,6 +4,7 @@ import Forbidden from './Forbidden';
 import InternalServer from './InternalServer';
 import NotFound from './NotFound';
 import Unauthorized from './Unauthorized';
+import UnprocessableEntity from './UnprocessableEntity';
 
 export default {
   BadRequest,
@@ -12,4 +13,5 @@ export default {
   InternalServer,
   NotFound,
   Unauthorized,
+  UnprocessableEntity,
 };

--- a/new-api/tsconfig.json
+++ b/new-api/tsconfig.json
@@ -14,7 +14,8 @@
     "paths": {
 			"@modules/*": ["./v2/modules/*"],
 			"@config/*": ["./v2/config/*"],
-			"@providers/*": ["./v2/providers/*"]
+			"@providers/*": ["./v2/providers/*"],
+			"@utils/*": ["./v2/utils/*"]
 		}
   }
 }


### PR DESCRIPTION
Criando os teste para os serviços de membros

**OBJETIVO**: Deixar todos os teste unitários do service de membros finalizados e padronizados.

**Atividades**: Conferir se os teste já foram feitos, e se cobrem todos os cenários, e criar os que faltarem.

- [x] createMember.service.ts
- [x] deleteMember.service.ts
- [x] findAllMember.service.ts
- [x] findMemberByID.service.ts
- [x] findMemberByLogin.service.ts
- [x] updateAvatarMember.service.ts
- [x] updateMember.service.ts
- [x] updatePatentMember.service.ts

[Task aqui](https://trello.com/c/9os9b7mw)